### PR TITLE
fix: cast math aggregates to double in QA summary

### DIFF
--- a/lib/services/qc_rules.dart
+++ b/lib/services/qc_rules.dart
@@ -91,11 +91,11 @@ QaSummary summarizeQa(
       point: points[i],
     );
     qaCounts[level] = (qaCounts[level] ?? 0) + 1;
-    rss += math.pow(residual * 100, 2);
+    rss += math.pow(residual * 100, 2).toDouble();
     obsCount += 1;
     final contact = points[i].contactRMax;
     if (contact != null) {
-      worstContact = math.max(worstContact ?? contact, contact);
+      worstContact = math.max(worstContact ?? contact, contact).toDouble();
     }
   }
 
@@ -107,7 +107,7 @@ QaSummary summarizeQa(
           final fit = fitted[index].abs();
           final resid = residuals[index] * fit;
           final weight = sigma == 0 ? 1 : 1 / sigma;
-          return math.pow(resid * weight, 2);
+          return math.pow(resid * weight, 2).toDouble();
         }).fold<double>(0, (a, b) => a + b) /
           obsCount;
   return QaSummary(


### PR DESCRIPTION
## Summary
- ensure math.pow and math.max results are converted to double within the QA summary calculations to satisfy type checks

## Testing
- flutter analyze *(fails: Flutter SDK is not available in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dd97d599d0832eb532d9a868011a96