### PR TITLE
Remove binary Android launcher icons and expand setup guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,52 +14,31 @@ VES QC is a field-ready, offline-first Flutter companion for geophysicists valid
 └── analysis_options.yaml   # Lint configuration
 ```
 
-## Getting started (brand-new Android & Flutter setup)
+## Getting started on Android
 
-If you have never shipped an Android app before, work through each section in order. Every command runs from the repository root unless noted otherwise.
+### 1. One-time prerequisites
 
-### 1. Install prerequisites
+If this is your first Flutter + Android install, work through the list and check off each item before opening the project.
 
-1. **Flutter SDK** (3.19 or newer)
-   - Follow the official installation guide for your platform: <https://docs.flutter.dev/get-started/install>.
-   - Extract Flutter, add `flutter/bin` to your system `PATH`, then restart your terminal.
-2. **Android Studio**
-   - Download from <https://developer.android.com/studio>.
-   - During the first launch, keep the default components (Android SDK, Android SDK Platform, Android Virtual Device).
-3. **Android command-line tools**
-   - From Android Studio, open **More Actions → SDK Manager**.
-   - Install at least one Android SDK platform (Android 14 or Android 13 recommended) and the **Android SDK Command-line Tools** package.
-4. **Enable virtualization (for emulators)**
-   - Windows: enable Hyper-V or Windows Hypervisor Platform via "Turn Windows features on or off".
-   - macOS: Apple Silicon requires Rosetta + virtualization framework (usually already enabled).
-5. **Git** (already included on macOS/Linux; Windows users can install from <https://git-scm.com/downloads>).
+- **Flutter SDK** (3.19 or newer). Follow the platform guide at <https://docs.flutter.dev/get-started/install>, unzip the SDK, and add `flutter/bin` to your `PATH`.
+- **Android Studio** with the default components (Android SDK, platform tools, and Android Virtual Device). Download from <https://developer.android.com/studio>.
+- **Android SDK Platform + command-line tools.** In Android Studio open **More Actions → SDK Manager**, then install Android 14 (API 34) or Android 13 (API 33) and the "Android SDK Command-line Tools" package.
+- **Virtualization** if you plan to use emulators. Enable Hyper-V or Windows Hypervisor Platform on Windows, and ensure Apple Virtualization is enabled/Rosetta installed on Apple Silicon Macs.
+- **Git** (already available on macOS/Linux; Windows installers live at <https://git-scm.com/downloads>).
 
-### 2. Verify your Flutter environment
+Run `flutter doctor` afterwards and accept any pending Android licenses with `flutter doctor --android-licenses`.
 
-```
-flutter doctor
-```
+### 2. Project bootstrap
 
-- Resolve every reported issue. For Android licenses, run:
-
-```
-flutter doctor --android-licenses
-```
-
-### 3. Clone the project
+Clone the repository and pull dependencies:
 
 ```
 git clone https://github.com/Balooog/1D_ERT_FIELD_APP.git
 cd 1D_ERT_FIELD_APP
-```
-
-### 4. Fetch dependencies and run static checks
-
-```
 flutter pub get
 ```
 
-Optional but recommended checks:
+Optional—but very helpful when you are editing code—run the built-in checks:
 
 ```
 flutter format .
@@ -67,48 +46,57 @@ flutter analyze
 flutter test
 ```
 
-### 5. Prepare a device
-
-You need either a hardware Android device or an emulator.
-
-- **Physical device**
-  1. Enable *Developer options* (tap the build number 7 times in Settings → About phone).
-  2. Turn on *USB debugging*.
-  3. Connect via USB and accept the RSA fingerprint prompt.
-
-- **Android emulator**
-  1. Launch Android Studio → **More Actions → Virtual Device Manager**.
-  2. Create a new device (Pixel 6 / Android 14 works well) and start it.
-
-Verify that Flutter can see the device:
+### 3. Daily development workflow
 
 ```
-flutter devices
+flutter run        # attach to a connected device or emulator
+flutter build apk  # assemble a release APK
+
+make dev           # convenience wrapper around flutter run
+make test          # widget + unit tests
+make apk           # release build
 ```
 
-### 6. Run the app
+Hot reload stays available inside the `flutter run` session via `r` (reload) and `R` (restart).
 
-```
-flutter run
-```
+### 4. Device & emulator setup
 
-Hot reload is available with `r` (hot reload) or `R` (hot restart) while the command is running.
+#### Samsung Tab Active4 Pro (field hardware)
 
-### 7. Build a release APK
+We target the Samsung Tab Active4 Pro (Android 12/13, 10.1" 1920×1200) for on-site validation. To prepare a tablet:
 
-```
-flutter build apk --release
-```
+1. Enable **Developer options** (Settings → About tablet → tap *Build number* seven times).
+2. Inside **Developer options**, toggle **USB debugging** and (optionally) **Stay awake** to keep the display on while charging.
+3. Under **Developer options → Input**, enable **Show taps** while testing glove/wet-touch gestures.
+4. Connect over USB-C and accept the computer's RSA fingerprint prompt.
+5. Confirm visibility with `flutter devices`. The output should list a device with `android-arm64` architecture.
 
-You will find the generated APK at `build/app/outputs/flutter-apk/app-release.apk`.
+Reference hardware highlights for the crew in the field:
 
-### 8. Common Makefile shortcuts
+| Spec / feature | Samsung Tab Active4 Pro |
+| --- | --- |
+| OS | Android 12 / 13 |
+| Screen | 10.1", glove & wet-touch, 1920×1200 |
+| Rugged rating | IP68, MIL-STD-810H |
+| Hot-swappable battery | Yes (7,600 mAh equivalent) |
+| Replaceable | Easy slide & swap |
+| Weight | ~670 g (1.5 lbs) |
+| Connectivity | Wi-Fi, optional LTE, Bluetooth |
+| Built-in GNSS | GPS, GLONASS, BeiDou, Galileo |
 
-```
-make dev   # flutter run with hot reload flags
-make test  # flutter test
-make apk   # flutter build apk --release
-```
+The integrated GNSS is ideal for QA/inspection workflows even though it is not survey grade. Verify `Settings → Location` is enabled before heading to the field.
+
+#### Emulator configuration (Samsung-class tablet)
+
+1. Launch Android Studio → **More Actions → Virtual Device Manager**.
+2. Create a **Tablet** profile. If the Tab Active4 Pro image is unavailable, the "Galaxy Tab S7 FE" or "Pixel Tablet" profile approximates the 10.1" 1920×1200 layout.
+3. Choose a system image that matches field devices—Android 13 (API 33) works well because it aligns with the Tab Active4 Pro shipping version. Download the Google Play image so you can test location services and Play-dependent libraries.
+4. Edit the hardware profile before creating the device: set RAM to **4 GB**, storage to **16 GB**, and enable **Use Host GPU** for responsive OpenGL rendering.
+5. After the virtual device boots, open **Extended controls → Display** and set the resolution to **1920 × 1200**, 60 Hz, landscape orientation. Lock the orientation and disable automatic screen sleep under **Settings → Display** inside the emulator.
+6. Configure sensors in **Extended controls → Settings**: enable **Multi-touch**, set **Pressure** to "Uniform," and toggle **Simulate wet fingers** to mimic the rugged tablet digitizer.
+7. (Optional) In **Extended controls → Battery**, enable a custom profile (e.g., 40% with performance throttling) to validate hot-swap scenarios, and in **Location**, load GPX/KML tracks that match survey routes.
+
+When the emulator is running, `flutter devices` should list an `android-x64` device. Launch the app with `flutter run`, press `M` to toggle multi-touch emulation, and use `Ctrl` + `Shift` + `L` (or `Cmd` + `Shift` + `L`) to rotate between landscape orientations.
 
 ## Features snapshot
 

--- a/android/.gitignore
+++ b/android/.gitignore
@@ -1,0 +1,8 @@
+gradle-wrapper.jar
+/local.properties
+GeneratedPluginRegistrant.java
+GeneratedPluginRegistrant.swift
+GeneratedPluginRegistrant.m
+**/GeneratedPluginRegistrant.java
+**/GeneratedPluginRegistrant.swift
+**/GeneratedPluginRegistrant.m

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -1,0 +1,30 @@
+plugins {
+    id "com.android.application"
+    id "org.jetbrains.kotlin.android"
+    id "dev.flutter.flutter-gradle-plugin"
+}
+
+android {
+    namespace "com.vesqc.ves_qc"
+    compileSdkVersion flutter.compileSdkVersion
+    ndkVersion flutter.ndkVersion
+
+    defaultConfig {
+        applicationId "com.vesqc.ves_qc"
+        minSdkVersion flutter.minSdkVersion
+        targetSdkVersion flutter.targetSdkVersion
+        versionCode (flutter.versionCode != null ? flutter.versionCode.toInteger() : 1)
+        versionName (flutter.versionName ?: "1.0.0").toString()
+    }
+
+    buildTypes {
+        release {
+            // TODO: configure signing for production builds.
+            signingConfig signingConfigs.debug
+        }
+    }
+}
+
+flutter {
+    source '../..'
+}

--- a/android/app/src/debug/AndroidManifest.xml
+++ b/android/app/src/debug/AndroidManifest.xml
@@ -1,0 +1,4 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.vesqc.ves_qc">
+    <application android:usesCleartextTraffic="true" />
+</manifest>

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,0 +1,28 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.vesqc.ves_qc">
+    <application
+        android:label="VES QC"
+        android:name="${applicationName}"
+        android:icon="@mipmap/ic_launcher"
+        android:usesCleartextTraffic="false">
+        <activity
+            android:name="com.vesqc.ves_qc.MainActivity"
+            android:exported="true"
+            android:launchMode="singleTop"
+            android:theme="@style/LaunchTheme"
+            android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"
+            android:hardwareAccelerated="true"
+            android:windowSoftInputMode="adjustResize">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+        <meta-data
+            android:name="io.flutter.embedding.android.NormalTheme"
+            android:resource="@style/NormalTheme" />
+        <meta-data
+            android:name="flutterEmbedding"
+            android:value="2" />
+    </application>
+</manifest>

--- a/android/app/src/main/kotlin/com/vesqc/ves_qc/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/vesqc/ves_qc/MainActivity.kt
@@ -1,0 +1,5 @@
+package com.vesqc.ves_qc
+
+import io.flutter.embedding.android.FlutterActivity
+
+class MainActivity : FlutterActivity()

--- a/android/app/src/main/res/drawable-v21/launch_background.xml
+++ b/android/app/src/main/res/drawable-v21/launch_background.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:drawable="@color/launch_background" />
+</layer-list>

--- a/android/app/src/main/res/drawable/ic_launcher_background.xml
+++ b/android/app/src/main/res/drawable/ic_launcher_background.xml
@@ -1,0 +1,3 @@
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle">
+    <solid android:color="#0F172A" />
+</shape>

--- a/android/app/src/main/res/drawable/ic_launcher_foreground.xml
+++ b/android/app/src/main/res/drawable/ic_launcher_foreground.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+    <path
+        android:fillColor="#1D4ED8"
+        android:pathData="M12,12h84v84h-84z" />
+    <path
+        android:fillColor="#F9FAFB"
+        android:pathData="M36,54c0,-9.941 8.059,-18 18,-18s18,8.059 18,18 -8.059,18 -18,18 -18,-8.059 -18,-18z"
+        android:fillAlpha="0.9" />
+</vector>

--- a/android/app/src/main/res/drawable/launch_background.xml
+++ b/android/app/src/main/res/drawable/launch_background.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:drawable="@color/launch_background" />
+</layer-list>

--- a/android/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/android/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@drawable/ic_launcher_background" />
+    <foreground android:drawable="@drawable/ic_launcher_foreground" />
+</adaptive-icon>

--- a/android/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
+++ b/android/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@drawable/ic_launcher_background" />
+    <foreground android:drawable="@drawable/ic_launcher_foreground" />
+</adaptive-icon>

--- a/android/app/src/main/res/mipmap/ic_launcher.xml
+++ b/android/app/src/main/res/mipmap/ic_launcher.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@drawable/ic_launcher_background" />
+    <foreground android:drawable="@drawable/ic_launcher_foreground" />
+</adaptive-icon>

--- a/android/app/src/main/res/mipmap/ic_launcher_round.xml
+++ b/android/app/src/main/res/mipmap/ic_launcher_round.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@drawable/ic_launcher_background" />
+    <foreground android:drawable="@drawable/ic_launcher_foreground" />
+</adaptive-icon>

--- a/android/app/src/main/res/values-night/styles.xml
+++ b/android/app/src/main/res/values-night/styles.xml
@@ -1,0 +1,6 @@
+<resources>
+    <style name="LaunchTheme" parent="Theme.MaterialComponents.DayNight.NoActionBar">
+        <item name="android:windowBackground">@drawable/launch_background</item>
+        <item name="android:statusBarColor">@android:color/transparent</item>
+    </style>
+</resources>

--- a/android/app/src/main/res/values/colors.xml
+++ b/android/app/src/main/res/values/colors.xml
@@ -1,0 +1,4 @@
+<resources>
+    <color name="launch_background">#111827</color>
+    <color name="normal_background">#FFFFFFFF</color>
+</resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="app_name">VES QC</string>
+</resources>

--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -1,0 +1,9 @@
+<resources>
+    <style name="LaunchTheme" parent="Theme.MaterialComponents.DayNight.NoActionBar">
+        <item name="android:windowBackground">@drawable/launch_background</item>
+        <item name="android:statusBarColor">@android:color/transparent</item>
+    </style>
+    <style name="NormalTheme" parent="Theme.MaterialComponents.DayNight.NoActionBar">
+        <item name="android:windowBackground">@color/normal_background</item>
+    </style>
+</resources>

--- a/android/app/src/profile/AndroidManifest.xml
+++ b/android/app/src/profile/AndroidManifest.xml
@@ -1,0 +1,4 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.vesqc.ves_qc">
+    <application android:usesCleartextTraffic="true" />
+</manifest>

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,0 +1,5 @@
+plugins {
+    id "dev.flutter.flutter-plugin-loader" version "1.0.0"
+    id "com.android.application" version "8.2.1" apply false
+    id "org.jetbrains.kotlin.android" version "1.9.22" apply false
+}

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,0 +1,3 @@
+org.gradle.jvmargs=-Xmx1536M
+android.useAndroidX=true
+android.enableJetifier=true

--- a/android/gradlew
+++ b/android/gradlew
@@ -1,0 +1,8 @@
+#!/usr/bin/env sh
+set -e
+if command -v gradle >/dev/null 2>&1; then
+  gradle "$@"
+else
+  echo "Gradle is required but was not found in PATH. Install Gradle or generate the wrapper via 'flutter create .'" >&2
+  exit 1
+fi

--- a/android/gradlew.bat
+++ b/android/gradlew.bat
@@ -1,0 +1,9 @@
+@ECHO OFF
+SETLOCAL
+WHERE gradle >NUL 2>&1
+IF %ERRORLEVEL% EQU 0 (
+  gradle %*
+) ELSE (
+  ECHO Gradle is required but was not found in PATH. Install Gradle or generate the wrapper via "flutter create ." >&2
+  EXIT /B 1
+)

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,0 +1,39 @@
+pluginManagement {
+    def flutterSdkPath = {
+        def envValue = System.getenv('FLUTTER_HOME')
+        if (envValue != null) {
+            return envValue
+        }
+
+        def properties = new Properties()
+        def propertiesFile = new File(settingsDir, 'local.properties')
+        if (propertiesFile.exists()) {
+            propertiesFile.withReader('UTF-8') { reader -> properties.load(reader) }
+            def flutterSdkPathFromFile = properties.getProperty('flutter.sdk')
+            if (flutterSdkPathFromFile != null) {
+                return flutterSdkPathFromFile
+            }
+        }
+
+        throw new GradleException('Flutter SDK not found. Define location with FLUTTER_HOME or in local.properties.')
+    }()
+
+    includeBuild("$flutterSdkPath/packages/flutter_tools/gradle")
+
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
+rootProject.name = "ves_qc"
+include(":app")


### PR DESCRIPTION
## Summary
- replace raster mipmap launcher icons with adaptive-icon XML drawables so the Android build no longer depends on binary assets
- expand the Samsung Tab Active4 Pro onboarding section with a hardware reference table and richer emulator configuration guidance

## Testing
- not run (Flutter SDK not available in the environment)

------
https://chatgpt.com/codex/tasks/task_e_68de6c9f9c08832eb5a4d818eed0b555