### PR TITLE
Update formatting command to use dart format

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ test:
 flutter test
 
 format:
-flutter format .
+dart format .
 
 analyze:
 flutter analyze

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ flutter pub get
 Optional—but very helpful when you are editing code—run the built-in checks:
 
 ```
-flutter format .
+dart format .
 flutter analyze
 flutter test
 ```


### PR DESCRIPTION
## Summary
- switch the Makefile's format target to use `dart format .` which is available in the Flutter SDK
- update the README instructions to recommend `dart format .`

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de7478f388832e956a3096bae18345