### PR TITLE
Fix analyzer type errors in tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ test:
 flutter test
 
 format:
-flutter format .
+dart format .
 
 analyze:
 flutter analyze

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ flutter pub get
 Optional—but very helpful when you are editing code—run the built-in checks:
 
 ```
-flutter format .
+dart format .
 flutter analyze
 flutter test
 ```

--- a/test/inversion_test.dart
+++ b/test/inversion_test.dart
@@ -8,19 +8,19 @@ void main() {
   test('Lite inversion returns model', () {
     final points = List.generate(5, (index) {
       final spacing = 1.0 + index;
-      final rho = 100 + index * 5;
+      final rho = 100.0 + index * 5;
       return SpacingPoint(
         id: '$index',
         arrayType: ArrayType.wenner,
         spacingMetric: spacing,
-        vp: 1,
+        vp: 1.0,
         current: 0.5,
         contactR: const {},
-        spDriftMv: 0,
+        spDriftMv: 0.0,
         stacks: 1,
         repeats: null,
         rhoApp: rho,
-        sigmaRhoApp: 2,
+        sigmaRhoApp: 2.0,
         timestamp: DateTime.now(),
       );
     });

--- a/test/qc_rules_test.dart
+++ b/test/qc_rules_test.dart
@@ -4,15 +4,15 @@ import 'package:ves_qc/models/enums.dart';
 import 'package:ves_qc/models/spacing_point.dart';
 import 'package:ves_qc/services/qc_rules.dart';
 
-SpacingPoint _makePoint(double rho, {double? sigma, double residual = 0}) {
+SpacingPoint _makePoint(double rho, {double? sigma}) {
   return SpacingPoint(
     id: '1',
     arrayType: ArrayType.wenner,
-    spacingMetric: 5,
-    vp: 1,
+    spacingMetric: 5.0,
+    vp: 1.0,
     current: 0.5,
-    contactR: const {'c1': 100, 'c2': 150},
-    spDriftMv: 1,
+    contactR: const {'c1': 100.0, 'c2': 150.0},
+    spDriftMv: 1.0,
     stacks: 1,
     repeats: null,
     rhoApp: rho,
@@ -23,25 +23,25 @@ SpacingPoint _makePoint(double rho, {double? sigma, double residual = 0}) {
 
 void main() {
   test('Green classification', () {
-    final point = _makePoint(100, sigma: 2);
+    final point = _makePoint(100.0, sigma: 2.0);
     final level = classifyPoint(residual: 0.02, coefficientOfVariation: 0.02, point: point);
     expect(level, QaLevel.green);
   });
 
   test('Red classification due to CV', () {
-    final point = _makePoint(100, sigma: 20);
+    final point = _makePoint(100.0, sigma: 20.0);
     final level = classifyPoint(residual: 0.02, coefficientOfVariation: 0.2, point: point);
     expect(level, QaLevel.red);
   });
 
   test('Summary counts', () {
     final points = [
-      _makePoint(100, sigma: 2),
-      _makePoint(90, sigma: 5),
-      _makePoint(150, sigma: 30),
+      _makePoint(100.0, sigma: 2.0),
+      _makePoint(90.0, sigma: 5.0),
+      _makePoint(150.0, sigma: 30.0),
     ];
     final residuals = [0.02, 0.07, 0.2];
-    final fitted = [100, 95, 140];
+    final fitted = [100.0, 95.0, 140.0];
     final summary = summarizeQa(points, residuals, fitted);
     expect(summary.green, greaterThanOrEqualTo(1));
     expect(summary.red, greaterThanOrEqualTo(1));


### PR DESCRIPTION
## Summary
- update `test/inversion_test.dart` to use double literals for `SpacingPoint` construction
- ensure `test/qc_rules_test.dart` uses double-typed data and remove the unused helper parameter while tidying formatting

## Testing
- dart format . *(fails: dart command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68de7478f388832e956a3096bae18345