### PR TITLE
Remove unused import from home screen

### DIFF
--- a/lib/ui/screens/home_screen.dart
+++ b/lib/ui/screens/home_screen.dart
@@ -9,7 +9,6 @@ import '../../models/enums.dart';
 import '../../models/spacing_point.dart';
 import '../../services/csv_io.dart';
 import '../../services/geometry_factors.dart';
-import '../../services/qc_rules.dart';
 import '../../state/providers.dart';
 import '../widgets/header_badges.dart';
 import '../widgets/residual_strip.dart';


### PR DESCRIPTION
## Summary
- remove the unused qc_rules import from the home screen widget to clear the analyzer warning

## Testing
- flutter analyze *(fails: flutter command unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68de7d6ca0c4832eab0491900415c164