### PR TITLE
fix: stabilize qa metric calculations

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ flutter test
 ### 3. Daily development workflow
 
 ```
+flutter create .   # regenerate platform wrappers when missing
 flutter run        # attach to a connected device or emulator
 flutter build apk  # assemble a release APK
 

--- a/lib/services/inversion.dart
+++ b/lib/services/inversion.dart
@@ -16,8 +16,6 @@ class LiteInversionService {
     }
     final spacings = usable.map((e) => e.spacingMetric).toList();
     final observations = usable.map((e) => e.rhoApp).toList();
-    final logSpacing = spacings.map((e) => math.log(e)).toList();
-
     final seeds = _seedModel(spacings, observations);
     var logRhos = seeds.rhos.map(math.log).toList();
     final thicknesses = seeds.thicknesses;
@@ -249,11 +247,18 @@ class LiteInversionService {
     if (slopes.isEmpty) {
       return List<double>.filled(count, spacing.first);
     }
-    final absSlopes = List<double>.from(slopes.map((e) => e.abs()))..sort((a, b) => b.compareTo(a));
+    final sortedIndices = List<int>.generate(slopes.length, (i) => i)
+      ..sort((a, b) => slopes[b].abs().compareTo(slopes[a].abs()));
     final breaks = <double>[];
     for (var i = 0; i < count; i++) {
-      final idx = math.min(i, spacing.length - 1);
-      breaks.add(spacing[idx]);
+      if (sortedIndices.isEmpty) {
+        final idx = math.min(i, spacing.length - 1);
+        breaks.add(spacing[idx]);
+      } else {
+        final slopeIndex = sortedIndices[math.min(i, sortedIndices.length - 1)] + 1;
+        final idx = math.min(slopeIndex, spacing.length - 1);
+        breaks.add(spacing[idx]);
+      }
     }
     return breaks;
   }

--- a/lib/services/qc_rules.dart
+++ b/lib/services/qc_rules.dart
@@ -76,8 +76,8 @@ QaSummary summarizeQa(
     );
   }
 
-  double rss = 0;
-  double obsCount = 0;
+  double rss = 0.0;
+  var obsCount = 0;
   final qaCounts = {QaLevel.green: 0, QaLevel.yellow: 0, QaLevel.red: 0};
   double? worstContact;
 
@@ -99,16 +99,16 @@ QaSummary summarizeQa(
     }
   }
 
-  final rms = obsCount == 0 ? 0 : math.sqrt(rss / obsCount);
+  final rms = obsCount == 0 ? 0.0 : math.sqrt(rss / obsCount);
   final chiSq = obsCount == 0
-      ? 0
+      ? 0.0
       : List.generate(points.length, (index) {
           final sigma = points[index].sigmaRhoApp ?? (0.05 * points[index].rhoApp.abs());
           final fit = fitted[index].abs();
           final resid = residuals[index] * fit;
           final weight = sigma == 0 ? 1 : 1 / sigma;
           return math.pow(resid * weight, 2).toDouble();
-        }).fold<double>(0, (a, b) => a + b) /
+        }).fold<double>(0.0, (a, b) => a + b) /
           obsCount;
   return QaSummary(
     green: qaCounts[QaLevel.green]!,


### PR DESCRIPTION
## Summary
- ensure QA summary metrics use doubles so Flutter analyze/test compile cleanly
- refine inversion seeding to prioritize largest log-slope transitions and remove unused values

## Testing
- not run (Flutter/Dart SDK unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68de7f981608832ea3329aa794599fb7