### PR TITLE
Fix widget test to use VesQcApp root widget

### DIFF
--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1,0 +1,12 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:ves_qc/main.dart';
+
+void main() {
+  testWidgets('smoke: app builds under ProviderScope', (tester) async {
+    await tester.pumpWidget(const ProviderScope(child: VesQcApp()));
+    await tester.pumpAndSettle();
+    expect(find.byType(MaterialApp), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- update the default widget smoke test to import `VesQcApp` from `lib/main.dart`
- wrap the widget in a `ProviderScope` so it matches the real app bootstrap

## Testing
- Not run (flutter tooling unavailable in container)

Resolves the `MyApp` test failure (`creation_with_non_type`).

------
https://chatgpt.com/codex/tasks/task_e_68de9465af34832ea53da9e1abdb5cfc