### PR TITLE
feat: support resistance-first feet spacing workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,14 +116,21 @@ A sample file lives at `assets/samples/sample_wenner.csv`.
 
 | Column | Unit | Description |
 | --- | --- | --- |
-| `spacing_m` | m | Electrode spacing metric (a or AB/2). |
-| `voltage_v` | V | Measured potential difference. |
-| `current_a` | A | Injected current magnitude. |
+| `a_spacing_ft` | ft | Wenner A-spacing in feet (as entered in the field). |
+| `a_spacing_m` | m | A-spacing converted to meters (export convenience). |
+| `spacing_m` | m | Legacy spacing column; treated the same as `a_spacing_m` on import. |
+| `resistance_ohm` | Ω | Measured line resistance from the instrument. |
+| `resistance_std_ohm` | Ω | Optional standard deviation of the resistance reading. |
+| `direction` | text | `ns`, `we`, or `other` (sounding orientation). |
+| `voltage_v` | V | Optional potential measurement for QA (advanced). |
+| `current_a` | A | Optional injected current for QA (advanced). |
 | `array_type` | text | `wenner`, `schlumberger`, `dipole_dipole`, `pole_dipole`, or `custom`. |
 | `mn_over_2_m` | m | Optional MN/2 spacing for Schlumberger geometries. |
-| `rho_app_ohm_m` | Ω·m | Apparent resistivity. |
-| `sigma_rho_app` | Ω·m | Standard deviation from repeats. |
+| `rho_app_ohm_m` | Ω·m | Apparent resistivity; derived as `2π a(m) · R`. |
+| `sigma_rho_app` | Ω·m | Propagated standard deviation of apparent resistivity. |
 | `timestamp_iso` | ISO8601 | Timestamp of acquisition. |
+
+`rho_app_ohm_m` is recomputed during import if not present, and legacy files with only `spacing_m`, `voltage_v`, and `current_a` remain supported.
 
 ## QA thresholds
 

--- a/lib/models/spacing_point.dart
+++ b/lib/models/spacing_point.dart
@@ -1,3 +1,5 @@
+import 'dart:math' as math;
+
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 import 'package:uuid/uuid.dart';
@@ -6,29 +8,211 @@ import 'enums.dart';
 
 typedef ContactResistances = Map<String, double>;
 
+enum SoundingDirection { ns, we, other }
+
+extension SoundingDirectionX on SoundingDirection {
+  String get label {
+    switch (this) {
+      case SoundingDirection.ns:
+        return 'N–S';
+      case SoundingDirection.we:
+        return 'W–E';
+      case SoundingDirection.other:
+        return 'Other';
+    }
+  }
+
+  String get csvValue => name;
+}
+
+SoundingDirection parseSoundingDirection(String? value) {
+  if (value == null) {
+    return SoundingDirection.other;
+  }
+  final normalized = value.trim().toLowerCase();
+  switch (normalized) {
+    case 'ns':
+    case 'n-s':
+    case 'n/s':
+    case 'n–s':
+    case 'north south':
+    case 'northsouth':
+    case 'north-south':
+      return SoundingDirection.ns;
+    case 'we':
+    case 'w-e':
+    case 'w/e':
+    case 'w–e':
+    case 'west east':
+    case 'eastwest':
+    case 'east-west':
+    case 'west-east':
+      return SoundingDirection.we;
+    default:
+      return SoundingDirection.other;
+  }
+}
+
+const double _metersPerFoot = 0.3048;
+
+double feetToMeters(double feet) => feet * _metersPerFoot;
+
+double metersToFeet(double meters) => meters / _metersPerFoot;
+
+class _ResolvedInputs {
+  const _ResolvedInputs({
+    required this.aFeet,
+    required this.resistanceOhm,
+    this.voltageV,
+    this.currentA,
+  });
+
+  final double aFeet;
+  final double resistanceOhm;
+  final double? voltageV;
+  final double? currentA;
+
+  static _ResolvedInputs resolve({
+    double? aFeet,
+    double? spacingMeters,
+    double? resistanceOhm,
+    double? voltageV,
+    double? currentA,
+    double? rhoApp,
+  }) {
+    double? resolvedFeet = aFeet;
+    double? resolvedMeters = spacingMeters;
+    if (resolvedFeet == null && resolvedMeters != null) {
+      resolvedFeet = metersToFeet(resolvedMeters);
+    }
+
+    double? resolvedResistance = resistanceOhm;
+    final double? voltage = voltageV;
+    final double? current = currentA;
+
+    if (resolvedResistance == null && rhoApp != null) {
+      resolvedMeters ??= resolvedFeet != null ? feetToMeters(resolvedFeet) : null;
+      if (resolvedMeters != null && resolvedMeters != 0) {
+        resolvedResistance = rhoApp / (2 * math.pi * resolvedMeters);
+      }
+    }
+
+    if (resolvedResistance == null && voltage != null && current != null && current != 0) {
+      resolvedResistance = voltage / current;
+    }
+
+    if (resolvedFeet == null) {
+      if (resolvedMeters != null) {
+        resolvedFeet = metersToFeet(resolvedMeters);
+      } else if (rhoApp != null && resolvedResistance != null && resolvedResistance != 0) {
+        final derivedMeters = rhoApp / (2 * math.pi * resolvedResistance);
+        resolvedMeters = derivedMeters;
+        resolvedFeet = metersToFeet(derivedMeters);
+      }
+    }
+
+    resolvedMeters ??= resolvedFeet != null ? feetToMeters(resolvedFeet) : null;
+
+    if (resolvedFeet == null) {
+      throw ArgumentError('A-spacing could not be resolved from the provided inputs.');
+    }
+    if (resolvedResistance == null) {
+      throw ArgumentError('Resistance (Ω) could not be resolved from the provided inputs.');
+    }
+
+    return _ResolvedInputs(
+      aFeet: resolvedFeet,
+      resistanceOhm: resolvedResistance,
+      voltageV: voltage,
+      currentA: current,
+    );
+  }
+}
+
 @immutable
 class SpacingPoint {
-  const SpacingPoint({
+  const SpacingPoint._({
     required this.id,
     required this.arrayType,
-    required this.spacingMetric,
-    required this.vp,
-    required this.current,
-    required this.contactR,
-    required this.spDriftMv,
+    required double aFeet,
+    required double resistanceOhm,
+    double? resistanceStdOhm,
+    required this.direction,
+    double? voltageV,
+    double? currentA,
+    required ContactResistances contactR,
+    this.spDriftMv,
     required this.stacks,
-    required this.repeats,
-    required this.rhoApp,
-    required this.sigmaRhoApp,
+    List<double>? repeats,
+    double? sigmaRhoLegacy,
     required this.timestamp,
     this.excluded = false,
-  });
+  })  : _aFeet = aFeet,
+        _resistanceOhm = resistanceOhm,
+        _resistanceStdOhm = resistanceStdOhm,
+        _voltageV = voltageV,
+        _currentA = currentA,
+        contactR = Map.unmodifiable(contactR),
+        repeats = repeats != null ? List.unmodifiable(repeats) : null,
+        _sigmaRhoLegacy = sigmaRhoLegacy;
+
+  factory SpacingPoint({
+    required String id,
+    required ArrayType arrayType,
+    double? aFeet,
+    double? spacingMetric,
+    double? resistanceOhm,
+    double? resistanceStdOhm,
+    SoundingDirection direction = SoundingDirection.other,
+    double? voltageV,
+    double? currentA,
+    double? vp,
+    double? current,
+    ContactResistances contactR = const {},
+    double? spDriftMv,
+    int stacks = 1,
+    List<double>? repeats,
+    double? rhoApp,
+    double? sigmaRhoApp,
+    DateTime? timestamp,
+    bool excluded = false,
+  }) {
+    final resolved = _ResolvedInputs.resolve(
+      aFeet: aFeet,
+      spacingMeters: spacingMetric,
+      resistanceOhm: resistanceOhm,
+      voltageV: voltageV ?? vp,
+      currentA: currentA ?? current,
+      rhoApp: rhoApp,
+    );
+
+    return SpacingPoint._(
+      id: id,
+      arrayType: arrayType,
+      aFeet: resolved.aFeet,
+      resistanceOhm: resolved.resistanceOhm,
+      resistanceStdOhm: resistanceStdOhm,
+      direction: direction,
+      voltageV: resolved.voltageV,
+      currentA: resolved.currentA,
+      contactR: contactR,
+      spDriftMv: spDriftMv,
+      stacks: stacks,
+      repeats: repeats,
+      sigmaRhoLegacy: sigmaRhoApp,
+      timestamp: timestamp ?? DateTime.now(),
+      excluded: excluded,
+    );
+  }
 
   factory SpacingPoint.newPoint({
     required ArrayType arrayType,
-    required double spacingMetric,
-    required double vp,
-    required double current,
+    required double aFeet,
+    required double resistanceOhm,
+    double? resistanceStdOhm,
+    SoundingDirection direction = SoundingDirection.other,
+    double? voltageV,
+    double? currentA,
     ContactResistances contactR = const {},
     double? spDriftMv,
     int stacks = 1,
@@ -40,63 +224,101 @@ class SpacingPoint {
     return SpacingPoint(
       id: const Uuid().v4(),
       arrayType: arrayType,
-      spacingMetric: spacingMetric,
-      vp: vp,
-      current: current,
-      contactR: Map.unmodifiable(contactR),
+      aFeet: aFeet,
+      resistanceOhm: resistanceOhm,
+      resistanceStdOhm: resistanceStdOhm,
+      direction: direction,
+      voltageV: voltageV,
+      currentA: currentA,
+      contactR: contactR,
       spDriftMv: spDriftMv,
       stacks: stacks,
-      repeats: repeats != null ? List.unmodifiable(repeats) : null,
-      rhoApp: 0,
+      repeats: repeats,
+      rhoApp: null,
       sigmaRhoApp: sigmaRhoApp,
-      timestamp: timestamp ?? DateTime.now(),
+      timestamp: timestamp,
       excluded: excluded,
     );
   }
 
   final String id;
   final ArrayType arrayType;
-  final double spacingMetric;
-  final double vp;
-  final double current;
+  final double _aFeet;
+  final double _resistanceOhm;
+  final double? _resistanceStdOhm;
+  final SoundingDirection direction;
+  final double? _voltageV;
+  final double? _currentA;
   final ContactResistances contactR;
   final double? spDriftMv;
   final int stacks;
   final List<double>? repeats;
-  final double rhoApp;
-  final double? sigmaRhoApp;
+  final double? _sigmaRhoLegacy;
   final DateTime timestamp;
   final bool excluded;
+
+  static const double resistanceQaThresholdPercent = 5;
+
+  double get aFeet => _aFeet;
+  double get aMeters => feetToMeters(_aFeet);
+  double get spacingMetric => aMeters;
+  double get resistanceOhm => _resistanceOhm;
+  double? get resistanceStdOhm => _resistanceStdOhm;
+  double get rhoAppOhmM => 2 * math.pi * aMeters * resistanceOhm;
+  double get rhoApp => rhoAppOhmM;
+  double? get sigmaRhoApp => _resistanceStdOhm != null
+      ? 2 * math.pi * aMeters * _resistanceStdOhm!
+      : _sigmaRhoLegacy;
+  double? get sigmaRhoAppFromResistance =>
+      _resistanceStdOhm != null ? 2 * math.pi * aMeters * _resistanceStdOhm! : null;
+  double? get voltageV => _voltageV;
+  double? get currentA => _currentA;
+  double get vp => _voltageV ?? (currentA != null ? resistanceOhm * currentA! : 0);
+  double get current => _currentA ?? (_voltageV != null && resistanceOhm != 0 ? _voltageV! / resistanceOhm : 0);
+
+  double? get rFromVi =>
+      (_voltageV != null && _currentA != null && _currentA != 0) ? _voltageV! / _currentA! : null;
+
+  double? get resistanceDiffPercent => rFromVi == null || resistanceOhm == 0
+      ? null
+      : ((rFromVi! - resistanceOhm).abs() / resistanceOhm) * 100;
+
+  bool get hasResistanceQaWarning =>
+      resistanceDiffPercent != null && resistanceDiffPercent! > resistanceQaThresholdPercent;
 
   double? get contactRMax =>
       contactR.values.isEmpty ? null : contactR.values.reduce((a, b) => a > b ? a : b);
 
   SpacingPoint copyWith({
     ArrayType? arrayType,
-    double? spacingMetric,
-    double? vp,
-    double? current,
+    double? aFeet,
+    double? resistanceOhm,
+    double? resistanceStdOhm,
+    SoundingDirection? direction,
+    double? voltageV,
+    double? currentA,
     ContactResistances? contactR,
     double? spDriftMv,
     int? stacks,
     List<double>? repeats,
-    double? rhoApp,
     double? sigmaRhoApp,
     DateTime? timestamp,
     bool? excluded,
   }) {
-    return SpacingPoint(
+    return SpacingPoint._(
       id: id,
       arrayType: arrayType ?? this.arrayType,
-      spacingMetric: spacingMetric ?? this.spacingMetric,
-      vp: vp ?? this.vp,
-      current: current ?? this.current,
-      contactR: contactR ?? this.contactR,
+      aFeet: aFeet ?? this.aFeet,
+      resistanceOhm: resistanceOhm ?? this.resistanceOhm,
+      resistanceStdOhm: resistanceStdOhm ?? this.resistanceStdOhm,
+      direction: direction ?? this.direction,
+      voltageV: voltageV ?? _voltageV,
+      currentA: currentA ?? _currentA,
+      contactR: contactR != null ? Map.unmodifiable(contactR) : this.contactR,
       spDriftMv: spDriftMv ?? this.spDriftMv,
       stacks: stacks ?? this.stacks,
-      repeats: repeats ?? this.repeats,
-      rhoApp: rhoApp ?? this.rhoApp,
-      sigmaRhoApp: sigmaRhoApp ?? this.sigmaRhoApp,
+      repeats: repeats != null ? List.unmodifiable(repeats) : this.repeats,
+      sigmaRhoLegacy: sigmaRhoApp ?? _sigmaRhoLegacy,
       timestamp: timestamp ?? this.timestamp,
       excluded: excluded ?? this.excluded,
     );
@@ -105,14 +327,21 @@ class SpacingPoint {
   Map<String, dynamic> toJson() => {
         'id': id,
         'arrayType': arrayType.name,
+        'aFeet': aFeet,
         'spacingMetric': spacingMetric,
+        'resistanceOhm': resistanceOhm,
+        'resistanceStdOhm': resistanceStdOhm,
+        'direction': direction.name,
         'vp': vp,
+        'voltageV': voltageV,
         'current': current,
+        'currentA': currentA,
         'contactR': contactR,
         'spDriftMv': spDriftMv,
         'stacks': stacks,
         'repeats': repeats,
-        'rhoApp': rhoApp,
+        'rhoApp': rhoAppOhmM,
+        'rhoAppOhmM': rhoAppOhmM,
         'sigmaRhoApp': sigmaRhoApp,
         'timestamp': timestamp.toIso8601String(),
         'excluded': excluded,
@@ -125,9 +354,13 @@ class SpacingPoint {
         (e) => e.name == json['arrayType'],
         orElse: () => ArrayType.custom,
       ),
-      spacingMetric: (json['spacingMetric'] as num).toDouble(),
-      vp: (json['vp'] as num).toDouble(),
-      current: (json['current'] as num).toDouble(),
+      aFeet: (json['aFeet'] as num?)?.toDouble(),
+      spacingMetric: (json['spacingMetric'] as num?)?.toDouble(),
+      resistanceOhm: (json['resistanceOhm'] as num?)?.toDouble(),
+      resistanceStdOhm: (json['resistanceStdOhm'] as num?)?.toDouble(),
+      direction: parseSoundingDirection(json['direction'] as String?),
+      voltageV: (json['voltageV'] as num?)?.toDouble() ?? (json['vp'] as num?)?.toDouble(),
+      currentA: (json['currentA'] as num?)?.toDouble() ?? (json['current'] as num?)?.toDouble(),
       contactR: Map.unmodifiable((json['contactR'] as Map?)?.map(
             (key, value) => MapEntry(key as String, (value as num).toDouble()),
           ) ??
@@ -135,7 +368,7 @@ class SpacingPoint {
       spDriftMv: (json['spDriftMv'] as num?)?.toDouble(),
       stacks: json['stacks'] as int? ?? 1,
       repeats: (json['repeats'] as List?)?.map((e) => (e as num).toDouble()).toList(),
-      rhoApp: (json['rhoApp'] as num).toDouble(),
+      rhoApp: (json['rhoAppOhmM'] as num?)?.toDouble() ?? (json['rhoApp'] as num?)?.toDouble(),
       sigmaRhoApp: (json['sigmaRhoApp'] as num?)?.toDouble(),
       timestamp: DateTime.parse(json['timestamp'] as String),
       excluded: json['excluded'] as bool? ?? false,
@@ -151,29 +384,33 @@ class SpacingPoint {
           const DeepCollectionEquality().equals(contactR, other.contactR) &&
           const ListEquality<double>().equals(repeats, other.repeats) &&
           arrayType == other.arrayType &&
-          spacingMetric == other.spacingMetric &&
-          vp == other.vp &&
-          current == other.current &&
+          aFeet == other.aFeet &&
+          resistanceOhm == other.resistanceOhm &&
+          resistanceStdOhm == other.resistanceStdOhm &&
+          direction == other.direction &&
+          voltageV == other.voltageV &&
+          currentA == other.currentA &&
           spDriftMv == other.spDriftMv &&
           stacks == other.stacks &&
-          rhoApp == other.rhoApp &&
-          sigmaRhoApp == other.sigmaRhoApp &&
           timestamp == other.timestamp &&
-          excluded == other.excluded;
+          excluded == other.excluded &&
+          _sigmaRhoLegacy == other._sigmaRhoLegacy;
 
   @override
   int get hashCode => Object.hash(
         id,
         arrayType,
-        spacingMetric,
-        vp,
-        current,
+        aFeet,
+        resistanceOhm,
+        resistanceStdOhm,
+        direction,
+        voltageV,
+        currentA,
         const DeepCollectionEquality().hash(contactR),
         spDriftMv,
         stacks,
         const ListEquality<double>().hash(repeats),
-        rhoApp,
-        sigmaRhoApp,
+        _sigmaRhoLegacy,
         timestamp,
         excluded,
       );

--- a/lib/services/mock_stream.dart
+++ b/lib/services/mock_stream.dart
@@ -65,12 +65,18 @@ class MockStreamService {
         3,
         (_) => rhoApp + rng.nextGaussian() * sigma,
       );
+      final resistance = voltage / options.current;
+      final sigmaR = sigma / (2 * math.pi * _spacing);
       final point = SpacingPoint(
         id: _uuid.v4(),
         arrayType: options.arrayType,
+        aFeet: metersToFeet(_spacing),
         spacingMetric: _spacing,
-        vp: voltage,
-        current: options.current,
+        resistanceOhm: resistance,
+        resistanceStdOhm: sigmaR,
+        direction: SoundingDirection.other,
+        voltageV: voltage,
+        currentA: options.current,
         contactR: contactR,
         spDriftMv: spDrift,
         stacks: 3,

--- a/lib/services/qc_rules.dart
+++ b/lib/services/qc_rules.dart
@@ -35,6 +35,7 @@ QaLevel classifyPoint({
       (absResidual > QaThresholds.greenResidual && absResidual <= QaThresholds.yellowResidual);
 
   if (isRed()) return QaLevel.red;
+  if (point.hasResistanceQaWarning) return QaLevel.yellow;
   if (isYellow()) return QaLevel.yellow;
   return QaLevel.green;
 }

--- a/lib/ui/widgets/point_details_sheet.dart
+++ b/lib/ui/widgets/point_details_sheet.dart
@@ -12,16 +12,43 @@ class PointDetailsSheet extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final excluded = point.excluded;
+    final diffPercent = point.resistanceDiffPercent;
     return Padding(
       padding: const EdgeInsets.all(16),
       child: Column(
         mainAxisSize: MainAxisSize.min,
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Text('Spacing: ${point.spacingMetric.toStringAsFixed(2)} m'),
-          Text('ρa: ${point.rhoApp.toStringAsFixed(2)} Ωm'),
-          Text('Current: ${point.current.toStringAsFixed(2)} A'),
-          Text('Voltage: ${point.vp.toStringAsFixed(3)} V'),
+          Text(
+            'A-Spacing: ${point.aFeet.toStringAsFixed(2)} ft (${point.aMeters.toStringAsFixed(2)} m)',
+          ),
+          Text('Resistance R: ${point.resistanceOhm.toStringAsFixed(2)} Ω'),
+          if (point.resistanceStdOhm != null)
+            Text('StdDev σR: ${point.resistanceStdOhm!.toStringAsFixed(2)} Ω'),
+          Text('ρa: ${point.rhoAppOhmM.toStringAsFixed(2)} Ω·m'),
+          if (point.sigmaRhoApp != null)
+            Text('σρ: ${point.sigmaRhoApp!.toStringAsFixed(2)} Ω·m'),
+          Text('Direction: ${point.direction.label}'),
+          if (point.voltageV != null)
+            Text('Voltage: ${point.voltageV!.toStringAsFixed(3)} V'),
+          if (point.currentA != null)
+            Text('Current: ${point.currentA!.toStringAsFixed(3)} A'),
+          if (point.rFromVi != null)
+            Text('R (V/I): ${point.rFromVi!.toStringAsFixed(2)} Ω'),
+          if (diffPercent != null)
+            Row(
+              children: [
+                Icon(
+                  point.hasResistanceQaWarning ? Icons.warning_amber_rounded : Icons.info_outline,
+                  color: point.hasResistanceQaWarning
+                      ? Colors.orange
+                      : Theme.of(context).colorScheme.primary,
+                  size: 18,
+                ),
+                const SizedBox(width: 6),
+                Text('ΔR vs V/I: ${diffPercent.toStringAsFixed(1)}%'),
+              ],
+            ),
           Text('Stacks: ${point.stacks}'),
           Text('SP drift: ${point.spDriftMv?.toStringAsFixed(2) ?? '—'} mV'),
           const SizedBox(height: 12),

--- a/lib/ui/widgets/sounding_chart.dart
+++ b/lib/ui/widgets/sounding_chart.dart
@@ -27,7 +27,7 @@ class SoundingChart extends StatelessWidget {
     final colors = <Color>[];
     final predictedSpots = <FlSpot>[];
     final upperSpots = <FlSpot>[];
-    final lowerSpots = <FlSpot>[];
+    final errorBars = <LineChartBarData>[];
 
     for (var i = 0; i < points.length; i++) {
       final p = points[i];
@@ -42,10 +42,25 @@ class SoundingChart extends StatelessWidget {
         if (i < sigma.length) {
           final frac = sigma[i];
           final upper = fit * (1 + frac.abs());
-          final lower = fit * (1 - frac.abs());
           upperSpots.add(FlSpot(x, _log10(upper)));
-          lowerSpots.add(FlSpot(x, _log10(math.max(lower, 1e-6))));
         }
+      }
+      if (p.sigmaRhoApp != null && p.sigmaRhoApp! > 0) {
+        final rho = p.rhoAppOhmM;
+        final upper = math.max(rho + p.sigmaRhoApp!, 1e-6);
+        final lower = math.max(rho - p.sigmaRhoApp!, 1e-6);
+        errorBars.add(
+          LineChartBarData(
+            spots: [
+              FlSpot(x, _log10(lower)),
+              FlSpot(x, _log10(upper)),
+            ],
+            isCurved: false,
+            color: Colors.grey,
+            barWidth: 1.5,
+            dotData: const FlDotData(show: false),
+          ),
+        );
       }
       final level = classifyPoint(
         residual: residual ?? 0,
@@ -55,6 +70,52 @@ class SoundingChart extends StatelessWidget {
       );
       colors.add(_qaColor(level));
     }
+
+    final lineBars = <LineChartBarData>[];
+    if (upperSpots.isNotEmpty) {
+      lineBars.add(
+        LineChartBarData(
+          spots: upperSpots,
+          isCurved: true,
+          color: Colors.blue.withOpacity(0.2),
+          dotData: const FlDotData(show: false),
+          belowBarData: BarAreaData(
+            show: true,
+            color: Colors.blue.withOpacity(0.1),
+          ),
+        ),
+      );
+    }
+    if (predictedSpots.isNotEmpty) {
+      lineBars.add(
+        LineChartBarData(
+          spots: predictedSpots,
+          isCurved: true,
+          color: Colors.blue,
+          dotData: const FlDotData(show: false),
+        ),
+      );
+    }
+    lineBars.addAll(errorBars);
+    final pointsBarIndex = lineBars.length;
+    lineBars.add(
+      LineChartBarData(
+        spots: spots,
+        isCurved: false,
+        barWidth: 0,
+        showingIndicators: List.generate(spots.length, (index) => index),
+        dotData: FlDotData(
+          show: true,
+          checkToShowDot: (spot, data) => true,
+          getDotPainter: (spot, percent, bar, index) => FlDotCirclePainter(
+            color: colors[index],
+            radius: 4,
+            strokeWidth: 1.5,
+            strokeColor: Colors.black,
+          ),
+        ),
+      ),
+    );
 
     return Padding(
       padding: const EdgeInsets.all(16.0),
@@ -82,51 +143,40 @@ class SoundingChart extends StatelessWidget {
             rightTitles: const AxisTitles(sideTitles: SideTitles(showTitles: false)),
             topTitles: const AxisTitles(sideTitles: SideTitles(showTitles: false)),
           ),
-          lineBarsData: [
-            if (upperSpots.isNotEmpty && lowerSpots.isNotEmpty)
-              LineChartBarData(
-                spots: upperSpots,
-                isCurved: true,
-                color: Colors.blue.withOpacity(0.2),
-                dotData: const FlDotData(show: false),
-                belowBarData: BarAreaData(
-                  show: true,
-                  color: Colors.blue.withOpacity(0.1),
-                ),
-              ),
-            LineChartBarData(
-              spots: predictedSpots,
-              isCurved: true,
-              color: Colors.blue,
-              dotData: const FlDotData(show: false),
-            ),
-            LineChartBarData(
-              spots: spots,
-              isCurved: false,
-              barWidth: 0,
-              showingIndicators: List.generate(spots.length, (index) => index),
-              dotData: FlDotData(
-                show: true,
-                checkToShowDot: (spot, data) => true,
-                getDotPainter: (spot, percent, bar, index) => FlDotCirclePainter(
-                  color: colors[index],
-                  radius: 4,
-                  strokeWidth: 1.5,
-                  strokeColor: Colors.black,
-                ),
-              ),
-            ),
-          ],
+          lineBarsData: lineBars,
           gridData: FlGridData(show: true, drawVerticalLine: true, drawHorizontalLine: true),
           lineTouchData: LineTouchData(
             handleBuiltInTouches: true,
+            touchTooltipData: LineTouchTooltipData(
+              getTooltipItems: (touchedSpots) {
+                return touchedSpots.map((spot) {
+                  if (spot.barIndex != pointsBarIndex) {
+                    return null;
+                  }
+                  final point = points[spot.spotIndex];
+                  final spacingFt = point.aFeet.toStringAsFixed(2);
+                  final spacingM = point.aMeters.toStringAsFixed(2);
+                  final rhoValue = point.rhoAppOhmM.toStringAsFixed(2);
+                  return LineTooltipItem(
+                    'a: $spacingFt ft ($spacingM m)\nρa: $rhoValue Ω·m',
+                    const TextStyle(color: Colors.white),
+                  );
+                }).whereType<LineTooltipItem>().toList();
+              },
+            ),
             touchCallback: (event, response) {
               if (event is FlTapUpEvent && response?.lineBarSpots != null) {
-                final index = response!.lineBarSpots!.first.spotIndex;
-                showModalBottomSheet(
-                  context: context,
-                  builder: (ctx) => PointDetailsSheet(point: points[index]),
-                );
+                final spotsData = response!.lineBarSpots!;
+                for (final barSpot in spotsData) {
+                  if (barSpot.barIndex == pointsBarIndex) {
+                    final index = barSpot.spotIndex;
+                    showModalBottomSheet(
+                      context: context,
+                      builder: (ctx) => PointDetailsSheet(point: points[index]),
+                    );
+                    break;
+                  }
+                }
               }
             },
           ),

--- a/test/csv_io_test.dart
+++ b/test/csv_io_test.dart
@@ -1,4 +1,5 @@
 import 'dart:io';
+import 'dart:math' as math;
 
 import 'package:flutter_test/flutter_test.dart';
 
@@ -7,28 +8,51 @@ import 'package:ves_qc/models/spacing_point.dart';
 import 'package:ves_qc/services/csv_io.dart';
 
 void main() {
-  test('CSV roundtrip', () async {
+  test('CSV roundtrip exports resistance-first columns', () async {
     final service = CsvIoService();
-    final temp = await File('${Directory.systemTemp.path}/ves_qc_test.csv').create(recursive: true);
-    final points = [
-      SpacingPoint(
-        id: '1',
-        arrayType: ArrayType.wenner,
-        spacingMetric: 5,
-        vp: 1,
-        current: 0.5,
-        contactR: const {},
-        spDriftMv: null,
-        stacks: 1,
-        repeats: null,
-        rhoApp: 100,
-        sigmaRhoApp: 2,
-        timestamp: DateTime.now(),
-      ),
-    ];
-    await service.writeFile(temp, points);
+    final temp = await File('${Directory.systemTemp.path}/ves_qc_test_new.csv').create(recursive: true);
+    final point = SpacingPoint(
+      id: '1',
+      arrayType: ArrayType.wenner,
+      aFeet: 10,
+      resistanceOhm: 25,
+      resistanceStdOhm: 1.5,
+      direction: SoundingDirection.ns,
+      voltageV: 12.5,
+      currentA: 0.5,
+      contactR: const {},
+      spDriftMv: null,
+      stacks: 1,
+      repeats: null,
+      rhoApp: 2 * math.pi * feetToMeters(10) * 25,
+      sigmaRhoApp: 2 * math.pi * feetToMeters(10) * 1.5,
+      timestamp: DateTime.now(),
+    );
+    await service.writeFile(temp, [point]);
+    final csv = await temp.readAsString();
+    expect(csv.contains(CsvColumns.aSpacingFt), isTrue);
+    expect(csv.contains(CsvColumns.resistance), isTrue);
     final readBack = await service.readFile(temp);
-    expect(readBack, isNotEmpty);
-    expect(readBack.first.rhoApp, points.first.rhoApp);
+    expect(readBack, hasLength(1));
+    final loaded = readBack.first;
+    expect(loaded.aFeet, closeTo(point.aFeet, 1e-6));
+    expect(loaded.resistanceOhm, closeTo(point.resistanceOhm, 1e-6));
+    expect(loaded.direction, point.direction);
+  });
+
+  test('Legacy CSV import derives resistance and preserves rho', () async {
+    final csv = [
+      'spacing_m,voltage_v,current_a,array_type,rho_app_ohm_m,sigma_rho_app,timestamp_iso',
+      '5,1.2,0.4,wenner,100,5,2024-01-01T00:00:00Z',
+    ].join('\n');
+    final file = await File('${Directory.systemTemp.path}/ves_qc_legacy.csv').create(recursive: true);
+    await file.writeAsString(csv);
+    final points = await CsvIoService().readFile(file);
+    expect(points, hasLength(1));
+    final point = points.first;
+    expect(point.aMeters, closeTo(5, 1e-6));
+    expect(point.rhoAppOhmM, closeTo(100, 1e-6));
+    expect(point.resistanceOhm, closeTo(100 / (2 * math.pi * 5), 1e-6));
+    expect(point.rFromVi, closeTo(1.2 / 0.4, 1e-6));
   });
 }

--- a/test/inversion_test.dart
+++ b/test/inversion_test.dart
@@ -1,3 +1,5 @@
+import 'dart:math' as math;
+
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:ves_qc/models/enums.dart';
@@ -9,12 +11,14 @@ void main() {
     final points = List.generate(5, (index) {
       final spacing = 1.0 + index;
       final rho = 100.0 + index * 5;
+      final resistance = rho / (2 * math.pi * spacing);
       return SpacingPoint(
         id: '$index',
         arrayType: ArrayType.wenner,
+        aFeet: metersToFeet(spacing),
         spacingMetric: spacing,
-        vp: 1.0,
-        current: 0.5,
+        resistanceOhm: resistance,
+        direction: SoundingDirection.other,
         contactR: const {},
         spDriftMv: 0.0,
         stacks: 1,

--- a/test/qc_rules_test.dart
+++ b/test/qc_rules_test.dart
@@ -1,3 +1,5 @@
+import 'dart:math' as math;
+
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:ves_qc/models/enums.dart';
@@ -5,12 +7,19 @@ import 'package:ves_qc/models/spacing_point.dart';
 import 'package:ves_qc/services/qc_rules.dart';
 
 SpacingPoint _makePoint(double rho, {double? sigma}) {
+  final spacingMeters = 5.0;
+  final resistance = rho / (2 * math.pi * spacingMeters);
+  final resistanceStd = sigma != null ? sigma / (2 * math.pi * spacingMeters) : null;
   return SpacingPoint(
     id: '1',
     arrayType: ArrayType.wenner,
-    spacingMetric: 5.0,
-    vp: 1.0,
-    current: 0.5,
+    aFeet: metersToFeet(spacingMeters),
+    spacingMetric: spacingMeters,
+    resistanceOhm: resistance,
+    resistanceStdOhm: resistanceStd,
+    direction: SoundingDirection.other,
+    voltageV: 1.0,
+    currentA: 0.5,
     contactR: const {'c1': 100.0, 'c2': 150.0},
     spDriftMv: 1.0,
     stacks: 1,

--- a/test/spacing_point_test.dart
+++ b/test/spacing_point_test.dart
@@ -1,0 +1,67 @@
+import 'dart:math' as math;
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:ves_qc/models/enums.dart';
+import 'package:ves_qc/models/spacing_point.dart';
+
+void main() {
+  test('feet to meters conversion', () {
+    expect(feetToMeters(2.0), closeTo(0.6096, 1e-6));
+  });
+
+  test('Wenner rho derives from spacing and resistance', () {
+    final point = SpacingPoint(
+      id: 'rho-test',
+      arrayType: ArrayType.wenner,
+      aFeet: 12.0,
+      resistanceOhm: 30.0,
+      direction: SoundingDirection.we,
+      contactR: const {},
+      spDriftMv: null,
+      stacks: 1,
+      repeats: null,
+      timestamp: DateTime(2024),
+    );
+    final expected = 2 * math.pi * point.aMeters * point.resistanceOhm;
+    expect(point.rhoAppOhmM, closeTo(expected, 1e-6));
+  });
+
+  test('Sigma propagation follows 2πa scaling', () {
+    final point = SpacingPoint(
+      id: 'sigma-test',
+      arrayType: ArrayType.wenner,
+      aFeet: 8.0,
+      resistanceOhm: 15.0,
+      resistanceStdOhm: 0.8,
+      direction: SoundingDirection.other,
+      contactR: const {},
+      spDriftMv: null,
+      stacks: 1,
+      repeats: null,
+      timestamp: DateTime(2024),
+    );
+    final expectedSigma = 2 * math.pi * point.aMeters * 0.8;
+    expect(point.sigmaRhoApp, closeTo(expectedSigma, 1e-6));
+  });
+
+  test('Resistance QA diff percent reflects V/I difference', () {
+    final point = SpacingPoint(
+      id: 'qa-test',
+      arrayType: ArrayType.wenner,
+      aFeet: 10.0,
+      resistanceOhm: 10.0,
+      direction: SoundingDirection.ns,
+      voltageV: 21.1,
+      currentA: 2.0,
+      contactR: const {},
+      spDriftMv: null,
+      stacks: 1,
+      repeats: null,
+      timestamp: DateTime(2024),
+    );
+    expect(point.rFromVi, closeTo(10.55, 1e-6));
+    expect(point.resistanceDiffPercent, closeTo(5.5, 1e-6));
+    expect(point.hasResistanceQaWarning, isTrue);
+  });
+}


### PR DESCRIPTION
## Summary
- add resistance-first spacing point model with feet-to-meters conversion, Wenner rho derivation, and QA helpers
- refresh manual point entry, charting, and details UI to capture A-spacing (ft), resistance, direction, and advanced QA with warnings
- extend CSV import/export, simulation data, and documentation to cover a_spacing_ft/resistance fields while keeping legacy formats working
- add unit tests covering conversion math, Wenner rho propagation, and CSV round-trips

## Testing
- Not run (per instructions; Flutter tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68de992ecf34832e9f899d4714f91756