### PR TITLE
feat: streamline manual entry with resistivity workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ResiCheck — 1D ERT Field App
 
-ResiCheck is a field-ready, offline-first Flutter companion for geophysicists validating 1-D ERT/VES soundings in real time. It focuses on quick situational awareness, defensive QA, and rapid iteration while staying lightweight for remote use.
+ResiCheck (formerly VES QC) is a field-ready, offline-first Flutter companion for geophysicists validating 1-D ERT/VES soundings in real time. It focuses on quick situational awareness, defensive QA, and rapid iteration while staying lightweight for remote use.
 
 ## Repository layout
 
@@ -12,6 +12,22 @@ ResiCheck is a field-ready, offline-first Flutter companion for geophysicists va
 ├── Makefile                # Helper commands for common Flutter workflows
 ├── pubspec.yaml            # Flutter project manifest and dependencies
 └── analysis_options.yaml   # Lint configuration
+```
+
+## Quick build on Windows (PowerShell)
+
+```
+cd C:\Users\abalo\Desktop\1D_ERT_FIELD_APP
+$env:PATH += ";C:\src\flutter\bin"
+git stash push -u -m "WIP"   # optional, avoids pull conflicts
+git checkout main
+git pull --rebase origin main
+flutter clean
+flutter pub get
+dart format . --set-exit-if-changed
+flutter analyze
+flutter test -x widget_dialog
+flutter run -d windows
 ```
 
 ## Getting started on Android
@@ -109,6 +125,8 @@ When the emulator is running, `flutter devices` should list an `android-x64` dev
 - **Simulation mode** for training/validation and offline demonstrations.
 - **CSV import/export** using the schema below.
 - **Manual data entry** for ad-hoc measurements.
+
+> **Simulate note:** The Simulate button drives the UI with synthetic mock streams for demos and training; it does not compute an SP profile from your last manual point.
 
 ## CSV schema
 

--- a/lib/ui/screens/home_screen.dart
+++ b/lib/ui/screens/home_screen.dart
@@ -9,6 +9,7 @@ import 'package:intl/intl.dart';
 import '../../models/enums.dart';
 import '../../models/spacing_point.dart';
 import '../../services/csv_io.dart';
+import '../../services/geometry_factors.dart' as geom;
 import '../../state/providers.dart';
 import '../widgets/header_badges.dart';
 import '../widgets/residual_strip.dart';
@@ -135,7 +136,9 @@ class HomeScreen extends ConsumerWidget {
   Future<void> _showAddPointDialog(BuildContext context, WidgetRef ref) async {
     final aFeetController = TextEditingController();
     final rhoController = TextEditingController();
+    final resistanceController = TextEditingController();
     final sigmaRhoController = TextEditingController();
+    final notesController = TextEditingController();
     final voltageController = TextEditingController();
     final currentController = TextEditingController();
     ArrayType arrayType = ArrayType.wenner;
@@ -145,222 +148,496 @@ class HomeScreen extends ConsumerWidget {
     await showDialog(
       context: context,
       builder: (ctx) {
-        return StatefulBuilder(builder: (ctx, setState) {
-          double? parseValue(TextEditingController controller) {
-            final text = controller.text.trim();
-            if (text.isEmpty) return null;
-            return double.tryParse(text);
-          }
+        return StatefulBuilder(
+          builder: (ctx, setState) {
+            double? parseValue(TextEditingController controller) {
+              final text = controller.text.trim();
+              if (text.isEmpty) return null;
+              return double.tryParse(text);
+            }
 
-          final aFeet = parseValue(aFeetController);
-          final rho = parseValue(rhoController);
-          final sigmaRho = parseValue(sigmaRhoController);
-          final aMeters = aFeet != null ? feetToMeters(aFeet) : null;
-          final voltage = parseValue(voltageController);
-          final current = parseValue(currentController);
-          final rhoFromVi = (voltage != null && current != null && current != 0 && aMeters != null)
-              ? 2 * math.pi * aMeters * (voltage / current)
-              : null;
-          final rhoDiffPercent = (rho != null && rhoFromVi != null && rho != 0)
-              ? ((rhoFromVi - rho).abs() / rho) * 100
-              : null;
-          final hasVoltage = voltageController.text.trim().isNotEmpty;
-          final hasCurrent = currentController.text.trim().isNotEmpty;
-          final bool baseValid = aFeet != null && aFeet > 0 && rho != null && rho > 0;
-          final bool sigmaValid = sigmaRho == null || sigmaRho >= 0;
-          final bool advancedPaired = hasVoltage == hasCurrent;
-          final bool advancedCurrentValid = current == null || current > 0;
-          final bool isAddEnabled = baseValid && sigmaValid && advancedPaired && advancedCurrentValid;
+            final spacingFeet = parseValue(aFeetController);
+            final spacingMeters = spacingFeet != null ? feetToMeters(spacingFeet) : null;
+            final geometryFactor = spacingMeters != null && spacingMeters > 0
+                ? _geometryFactorForArray(arrayType, spacingMeters)
+                : null;
+            final rhoInput = parseValue(rhoController);
+            final resistanceInput = parseValue(resistanceController);
+            final sigmaRho = parseValue(sigmaRhoController);
+            final voltage = parseValue(voltageController);
+            final current = parseValue(currentController);
 
-          return AlertDialog(
-            title: const Text('Add manual point'),
-            content: SingleChildScrollView(
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  DropdownButtonFormField<ArrayType>(
-                    value: arrayType,
-                    onChanged: (value) => setState(() => arrayType = value ?? arrayType),
-                    items: ArrayType.values
-                        .map((type) => DropdownMenuItem(value: type, child: Text(type.label)))
-                        .toList(),
-                  ),
-                  TextField(
-                    controller: aFeetController,
-                    decoration: const InputDecoration(labelText: 'A-Spacing (ft)'),
-                    keyboardType: const TextInputType.numberWithOptions(decimal: true),
-                    onChanged: (_) => setState(() {}),
-                  ),
-                  TextField(
-                    controller: rhoController,
-                    decoration: const InputDecoration(labelText: 'Apparent Resistivity ρ (Ω·m)'),
-                    keyboardType: const TextInputType.numberWithOptions(decimal: true),
-                    onChanged: (_) => setState(() {}),
-                  ),
-                  TextField(
-                    controller: sigmaRhoController,
-                    decoration: const InputDecoration(labelText: 'StdDev σρ (Ω·m)'),
-                    keyboardType: const TextInputType.numberWithOptions(decimal: true),
-                    onChanged: (_) => setState(() {}),
-                  ),
-                  DropdownButtonFormField<SoundingDirection>(
-                    value: direction,
-                    decoration: const InputDecoration(labelText: 'Direction'),
-                    onChanged: (value) => setState(() => direction = value ?? direction),
-                    items: SoundingDirection.values
-                        .map((dir) => DropdownMenuItem(value: dir, child: Text(dir.label)))
-                        .toList(),
-                  ),
-                  const SizedBox(height: 12),
-                  Align(
-                    alignment: Alignment.centerLeft,
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
+            final hasRho = rhoInput != null && rhoInput > 0;
+            final hasResistance = resistanceInput != null && resistanceInput > 0;
+
+            double? resolvedRhoValue = hasRho ? rhoInput : null;
+            double? resolvedResistanceValue;
+            if (hasRho && geometryFactor != null && geometryFactor > 0) {
+              resolvedResistanceValue = rhoInput! / geometryFactor;
+            } else if (!hasRho && hasResistance && geometryFactor != null && geometryFactor > 0) {
+              resolvedResistanceValue = resistanceInput;
+              resolvedRhoValue = resistanceInput! * geometryFactor;
+            }
+
+            final computedResistance =
+                hasRho && geometryFactor != null && geometryFactor > 0 ? rhoInput! / geometryFactor : null;
+            final computedRho = !hasRho && hasResistance && geometryFactor != null && geometryFactor > 0
+                ? resistanceInput! * geometryFactor
+                : null;
+
+            final rhoFromVi = (voltage != null && current != null && current != 0 && spacingMeters != null)
+                ? _geometryFactorForArray(arrayType, spacingMeters) * (voltage / current)
+                : null;
+            final rhoDiffPercent = (resolvedRhoValue != null && rhoFromVi != null && resolvedRhoValue != 0)
+                ? ((rhoFromVi - resolvedRhoValue).abs() / resolvedRhoValue) * 100
+                : null;
+
+            final hasVoltage = voltageController.text.trim().isNotEmpty;
+            final hasCurrent = currentController.text.trim().isNotEmpty;
+            final bool baseValid = spacingFeet != null &&
+                spacingFeet > 0 &&
+                resolvedRhoValue != null &&
+                resolvedRhoValue > 0 &&
+                (!hasResistance || geometryFactor != null && geometryFactor > 0);
+            final bool sigmaValid = sigmaRho == null || sigmaRho >= 0;
+            final bool advancedPaired = hasVoltage == hasCurrent;
+            final bool advancedCurrentValid = current == null || current > 0;
+            final bool isAddEnabled = baseValid && sigmaValid && advancedPaired && advancedCurrentValid;
+
+            return AlertDialog(
+              title: const Text('Add manual point'),
+              content: SingleChildScrollView(
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Row(
                       children: [
-                        Text('Spacing (m): ${aMeters != null ? aMeters.toStringAsFixed(3) : '—'}'),
-                        if (rho != null)
-                          Text('Apparent ρ (Ω·m): ${rho.toStringAsFixed(2)}'),
-                        if (sigmaRho != null)
-                          Text('σρ (Ω·m): ${sigmaRho.toStringAsFixed(2)}'),
-                        if (rhoDiffPercent != null)
-                          Text(
-                            'Δρ vs V/I: ${rhoDiffPercent.toStringAsFixed(1)}%',
-                            style: TextStyle(
-                              color: rhoDiffPercent > SpacingPoint.rhoQaThresholdPercent
-                                  ? Colors.orange
-                                  : Theme.of(context).colorScheme.onSurface,
+                        Expanded(
+                          child: DropdownButtonFormField<ArrayType>(
+                            value: arrayType,
+                            decoration: const InputDecoration(labelText: 'Array'),
+                            onChanged: (value) => setState(() => arrayType = value ?? arrayType),
+                            items: const [
+                              DropdownMenuItem(value: ArrayType.wenner, child: Text('Wenner')),
+                              DropdownMenuItem(value: ArrayType.schlumberger, child: Text('Schlumberger')),
+                            ],
+                          ),
+                        ),
+                        const SizedBox(width: 12),
+                        Expanded(
+                          child: DropdownButtonFormField<SoundingDirection>(
+                            value: direction,
+                            decoration: const InputDecoration(labelText: 'Direction'),
+                            onChanged: (value) => setState(() => direction = value ?? direction),
+                            items: SoundingDirection.values
+                                .map((dir) => DropdownMenuItem(value: dir, child: Text(dir.label)))
+                                .toList(),
+                          ),
+                        ),
+                      ],
+                    ),
+                    Align(
+                      alignment: Alignment.centerLeft,
+                      child: TextButton.icon(
+                        icon: const Icon(Icons.paste),
+                        label: const Text('Bulk paste'),
+                        onPressed: () async {
+                          final newDirection = await _showBulkPasteSheet(context, ref, arrayType, direction);
+                          if (newDirection != null) {
+                            setState(() => direction = newDirection);
+                          }
+                        },
+                      ),
+                    ),
+                    TextField(
+                      controller: aFeetController,
+                      decoration: const InputDecoration(labelText: 'A-spacing (ft)'),
+                      keyboardType: const TextInputType.numberWithOptions(decimal: true),
+                      onChanged: (_) => setState(() {}),
+                    ),
+                    if (spacingMeters != null)
+                      Align(
+                        alignment: Alignment.centerLeft,
+                        child: Padding(
+                          padding: const EdgeInsets.only(top: 4),
+                          child: Text(
+                            '≈ ${spacingMeters.toStringAsFixed(3)} m',
+                            style: Theme.of(context).textTheme.bodySmall,
+                          ),
+                        ),
+                      ),
+                    const SizedBox(height: 12),
+                    TextField(
+                      controller: rhoController,
+                      decoration: const InputDecoration(
+                        labelText: 'Apparent ρ (Ω·m)',
+                        helperText: 'Leave blank if you only logged apparent R',
+                      ),
+                      keyboardType: const TextInputType.numberWithOptions(decimal: true),
+                      onChanged: (_) => setState(() {}),
+                    ),
+                    if (computedResistance != null)
+                      Align(
+                        alignment: Alignment.centerLeft,
+                        child: Padding(
+                          padding: const EdgeInsets.only(top: 4),
+                          child: Text(
+                            'Computed R ≈ ${computedResistance.toStringAsFixed(3)} Ω',
+                            style: Theme.of(context).textTheme.bodySmall?.copyWith(fontStyle: FontStyle.italic),
+                          ),
+                        ),
+                      ),
+                    const SizedBox(height: 12),
+                    TextField(
+                      controller: resistanceController,
+                      decoration: const InputDecoration(
+                        labelText: 'Apparent R (Ω)',
+                        helperText: 'Provide if you logged resistance instead of ρ',
+                      ),
+                      keyboardType: const TextInputType.numberWithOptions(decimal: true),
+                      onChanged: (_) => setState(() {}),
+                    ),
+                    if (computedRho != null)
+                      Align(
+                        alignment: Alignment.centerLeft,
+                        child: Padding(
+                          padding: const EdgeInsets.only(top: 4),
+                          child: Text(
+                            'Computed ρ ≈ ${computedRho.toStringAsFixed(2)} Ω·m',
+                            style: Theme.of(context).textTheme.bodySmall?.copyWith(fontStyle: FontStyle.italic),
+                          ),
+                        ),
+                      ),
+                    if (!hasRho && !hasResistance)
+                      Align(
+                        alignment: Alignment.centerLeft,
+                        child: Padding(
+                          padding: const EdgeInsets.only(top: 4),
+                          child: Text(
+                            'Enter apparent ρ or apparent R.',
+                            style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                                  color: Theme.of(context).colorScheme.error,
+                                ),
+                          ),
+                        ),
+                      ),
+                    const SizedBox(height: 12),
+                    TextField(
+                      controller: sigmaRhoController,
+                      decoration: const InputDecoration(labelText: 'Std dev σρ (Ω·m, optional)'),
+                      keyboardType: const TextInputType.numberWithOptions(decimal: true),
+                      onChanged: (_) => setState(() {}),
+                    ),
+                    TextField(
+                      controller: notesController,
+                      decoration: const InputDecoration(labelText: 'Notes / tag (optional)'),
+                      keyboardType: TextInputType.text,
+                    ),
+                    const SizedBox(height: 12),
+                    if (resolvedRhoValue != null)
+                      Align(
+                        alignment: Alignment.centerLeft,
+                        child: Text(
+                          'Preview ρ: ${resolvedRhoValue.toStringAsFixed(2)} Ω·m',
+                          style: Theme.of(context).textTheme.bodySmall,
+                        ),
+                      ),
+                    if (resolvedResistanceValue != null)
+                      Align(
+                        alignment: Alignment.centerLeft,
+                        child: Text(
+                          'Preview R: ${resolvedResistanceValue.toStringAsFixed(3)} Ω',
+                          style: Theme.of(context).textTheme.bodySmall,
+                        ),
+                      ),
+                    if (rhoDiffPercent != null)
+                      Align(
+                        alignment: Alignment.centerLeft,
+                        child: Text(
+                          'Δρ vs V/I: ${rhoDiffPercent.toStringAsFixed(1)}%',
+                          style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                                color: rhoDiffPercent > SpacingPoint.rhoQaThresholdPercent
+                                    ? Colors.orange
+                                    : Theme.of(context).colorScheme.onSurface,
+                              ),
+                        ),
+                      ),
+                    const SizedBox(height: 12),
+                    ExpansionTile(
+                      title: const Text('Advanced'),
+                      initiallyExpanded: advancedExpanded,
+                      onExpansionChanged: (value) => setState(() => advancedExpanded = value),
+                      childrenPadding: const EdgeInsets.symmetric(horizontal: 8),
+                      children: [
+                        TextField(
+                          controller: voltageController,
+                          decoration: const InputDecoration(labelText: 'Potential (V)'),
+                          keyboardType: const TextInputType.numberWithOptions(decimal: true),
+                          onChanged: (_) => setState(() {}),
+                        ),
+                        TextField(
+                          controller: currentController,
+                          decoration: const InputDecoration(labelText: 'Current (A)'),
+                          keyboardType: const TextInputType.numberWithOptions(decimal: true),
+                          onChanged: (_) => setState(() {}),
+                        ),
+                        if (rhoFromVi != null)
+                          Padding(
+                            padding: const EdgeInsets.only(top: 8.0, bottom: 12),
+                            child: Align(
+                              alignment: Alignment.centerLeft,
+                              child: Text('ρ (from V/I): ${rhoFromVi.toStringAsFixed(2)} Ω·m'),
                             ),
                           ),
                       ],
                     ),
-                  ),
-                  const SizedBox(height: 12),
-                  ExpansionTile(
-                    title: const Text('Advanced'),
-                    initiallyExpanded: advancedExpanded,
-                    onExpansionChanged: (value) => setState(() => advancedExpanded = value),
-                    childrenPadding: const EdgeInsets.symmetric(horizontal: 8),
-                    children: [
-                      TextField(
-                        controller: voltageController,
-                        decoration: const InputDecoration(labelText: 'Potential (V)'),
-                        keyboardType: const TextInputType.numberWithOptions(decimal: true),
-                        onChanged: (_) => setState(() {}),
-                      ),
-                      TextField(
-                        controller: currentController,
-                        decoration: const InputDecoration(labelText: 'Current (A)'),
-                        keyboardType: const TextInputType.numberWithOptions(decimal: true),
-                        onChanged: (_) => setState(() {}),
-                      ),
-                      if (rhoFromVi != null)
-                        Padding(
-                          padding: const EdgeInsets.only(top: 8.0, bottom: 12),
-                          child: Align(
-                            alignment: Alignment.centerLeft,
-                            child: Text('ρ (from V/I): ${rhoFromVi.toStringAsFixed(2)} Ω·m'),
-                          ),
-                        ),
-                    ],
-                  ),
-                ],
+                  ],
+                ),
               ),
-            ),
-            actions: [
-              TextButton(onPressed: () => Navigator.pop(ctx), child: const Text('Cancel')),
-              FilledButton(
-                onPressed: isAddEnabled
-                    ? () {
-                      String? invalidField;
-                      double? parseRequired(TextEditingController controller, String label) {
-                        final text = controller.text.trim();
-                        final value = double.tryParse(text);
-                        if (text.isEmpty || value == null) {
-                          invalidField = label;
-                          return null;
-                        }
-                        if (value <= 0) {
-                          invalidField = '$label must be > 0';
-                          return null;
-                        }
-                        return value;
-                      }
-
-                      double? parseOptional(TextEditingController controller, {bool allowNegative = false}) {
-                        final text = controller.text.trim();
-                        if (text.isEmpty) return null;
-                        final value = double.tryParse(text);
-                        if (value == null) {
-                          invalidField = 'Invalid number "${controller.text}"';
-                          return null;
-                        }
-                        if (!allowNegative && value < 0) {
-                          invalidField = 'Values must be ≥ 0';
-                          return null;
-                        }
-                        return value;
-                      }
-
-                      final aFeetValue = parseRequired(aFeetController, 'A-Spacing (ft)');
-                      final rhoValue = parseRequired(rhoController, 'Apparent Resistivity ρ (Ω·m)');
-                      final sigmaRhoValue = parseOptional(sigmaRhoController);
-                      final voltageValue = parseOptional(voltageController);
-                      final currentValue = parseOptional(currentController);
-
-                      if ((voltageController.text.trim().isNotEmpty) !=
-                          (currentController.text.trim().isNotEmpty)) {
-                        invalidField = 'Provide both Potential and Current for advanced QA.';
-                      }
-
-                      if (invalidField != null || aFeetValue == null || rhoValue == null) {
-                        ScaffoldMessenger.of(context).showSnackBar(
-                          SnackBar(content: Text(invalidField ?? 'Please fill required fields.')),
-                        );
-                        return;
-                      }
-
-                      if (currentValue != null && currentValue == 0) {
-                        ScaffoldMessenger.of(context).showSnackBar(
-                          const SnackBar(content: Text('Current must be greater than zero.')),
-                        );
-                        return;
-                      }
-
-                      final aMetersValue = feetToMeters(aFeetValue);
-                      final manualId = DateFormat('yyyyMMddHHmmss').format(DateTime.now());
-                      final point = SpacingPoint(
-                        id: manualId,
-                        arrayType: arrayType,
-                        aFeet: aFeetValue,
-                        spacingMetric: aMetersValue,
-                        rhoAppOhmM: rhoValue,
-                        sigmaRhoOhmM: sigmaRhoValue,
-                        direction: direction,
-                        voltageV: voltageValue,
-                        currentA: currentValue,
-                        contactR: const {},
-                        spDriftMv: null,
-                        stacks: 1,
-                        repeats: null,
-                        timestamp: DateTime.now(),
-                      );
-
-                      ref.read(spacingPointsProvider.notifier).addPoint(point);
-                      if (voltageValue != null && currentValue != null) {
-                        ref.read(telemetryProvider.notifier).addSample(
-                              current: currentValue,
-                              voltage: voltageValue,
+              actions: [
+                TextButton(onPressed: () => Navigator.pop(ctx), child: const Text('Cancel')),
+                FilledButton(
+                  onPressed: isAddEnabled
+                      ? () {
+                          if (hasVoltage != hasCurrent) {
+                            ScaffoldMessenger.of(context).showSnackBar(
+                              const SnackBar(content: Text('Provide both Potential and Current for advanced QA.')),
                             );
-                      }
-                      Navigator.pop(ctx);
-                    }
-                    : null,
-                child: const Text('Add'),
-              ),
-            ],
-          );
-        });
+                            return;
+                          }
+                          if (current != null && current <= 0) {
+                            ScaffoldMessenger.of(context).showSnackBar(
+                              const SnackBar(content: Text('Current must be greater than zero.')),
+                            );
+                            return;
+                          }
+
+                          final spacingFeetValue = spacingFeet!;
+                          final spacingMetersValue = feetToMeters(spacingFeetValue);
+                          final geometry = _geometryFactorForArray(arrayType, spacingMetersValue);
+                          double? finalRho = resolvedRhoValue;
+                          double? finalResistance = resolvedResistanceValue;
+                          if (finalRho == null && hasResistance && geometry > 0) {
+                            finalRho = resistanceInput! * geometry;
+                            finalResistance = resistanceInput;
+                          }
+                          if (finalRho == null || finalRho <= 0) {
+                            ScaffoldMessenger.of(context).showSnackBar(
+                              const SnackBar(content: Text('Could not resolve apparent resistivity.')),
+                            );
+                            return;
+                          }
+                          final sigmaValue = sigmaRho != null && sigmaRho >= 0 ? sigmaRho : null;
+                          final manualId = DateFormat('yyyyMMddHHmmss').format(DateTime.now());
+                          try {
+                            final point = SpacingPoint(
+                              id: manualId,
+                              arrayType: arrayType,
+                              aFeet: spacingFeetValue,
+                              spacingMetric: spacingMetersValue,
+                              rhoAppOhmM: finalRho,
+                              sigmaRhoOhmM: sigmaValue,
+                              resistanceOhm: finalResistance,
+                              direction: direction,
+                              voltageV: voltage,
+                              currentA: current,
+                              contactR: const {},
+                              spDriftMv: null,
+                              stacks: 1,
+                              repeats: null,
+                              timestamp: DateTime.now(),
+                              notes: notesController.text.trim().isEmpty ? null : notesController.text.trim(),
+                            );
+                            ref.read(spacingPointsProvider.notifier).addPoint(point);
+                            if (voltage != null && current != null) {
+                              ref.read(telemetryProvider.notifier).addSample(
+                                    current: current,
+                                    voltage: voltage,
+                                  );
+                            }
+                            Navigator.pop(ctx);
+                          } catch (error) {
+                            ScaffoldMessenger.of(context).showSnackBar(
+                              SnackBar(content: Text('Could not add point: ${error.toString()}')),
+                            );
+                          }
+                        }
+                      : null,
+                  child: const Text('Add'),
+                ),
+              ],
+            );
+          },
+        );
       },
     );
+  }
+
+  Future<SoundingDirection?> _showBulkPasteSheet(
+    BuildContext context,
+    WidgetRef ref,
+    ArrayType arrayType,
+    SoundingDirection initialDirection,
+  ) async {
+    final pasteController = TextEditingController();
+    final bulkNotesController = TextEditingController(text: '${initialDirection.label} bulk');
+    SoundingDirection selectedDirection = initialDirection;
+    int? lastAdded;
+    List<String> skippedMessages = const [];
+    String? summary;
+
+    return showModalBottomSheet<SoundingDirection?>(
+      context: context,
+      isScrollControlled: true,
+      builder: (sheetCtx) {
+        return StatefulBuilder(
+          builder: (sheetCtx, setState) {
+            final bottomInset = MediaQuery.of(sheetCtx).viewInsets.bottom;
+            return Padding(
+              padding: EdgeInsets.only(left: 16, right: 16, top: 16, bottom: bottomInset + 16),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Text('Bulk paste points', style: Theme.of(sheetCtx).textTheme.titleMedium),
+                  const SizedBox(height: 12),
+                  DropdownButtonFormField<SoundingDirection>(
+                    value: selectedDirection,
+                    decoration: const InputDecoration(labelText: 'Orientation'),
+                    onChanged: (value) => setState(() => selectedDirection = value ?? selectedDirection),
+                    items: SoundingDirection.values
+                        .map((dir) => DropdownMenuItem(value: dir, child: Text(dir.label)))
+                        .toList(),
+                  ),
+                  TextField(
+                    controller: bulkNotesController,
+                    decoration: const InputDecoration(labelText: 'Notes / tag (optional)'),
+                  ),
+                  const SizedBox(height: 12),
+                  TextField(
+                    controller: pasteController,
+                    decoration: const InputDecoration(
+                      labelText: 'Rows (A ft, Ω)',
+                      alignLabelWithHint: true,
+                      hintText: 'Example: 10\t15',
+                    ),
+                    maxLines: 8,
+                    keyboardType: TextInputType.multiline,
+                  ),
+                  const SizedBox(height: 12),
+                  Row(
+                    children: [
+                      TextButton(
+                        onPressed: () => Navigator.pop(
+                          sheetCtx,
+                          lastAdded != null && lastAdded! > 0 ? selectedDirection : null,
+                        ),
+                        child: const Text('Close'),
+                      ),
+                      const Spacer(),
+                      FilledButton(
+                        onPressed: () {
+                          final raw = pasteController.text;
+                          final lines = raw.split(RegExp(r'\r?\n'));
+                          final notifier = ref.read(spacingPointsProvider.notifier);
+                          final newSkipped = <String>[];
+                          var added = 0;
+                          for (var i = 0; i < lines.length; i++) {
+                            final line = lines[i].trim();
+                            if (line.isEmpty) continue;
+                            final parts = line.split(RegExp(r'[\s,]+')).where((token) => token.isNotEmpty).toList();
+                            if (parts.length < 2) {
+                              newSkipped.add('Row ${i + 1}: expected A(ft) and Ω values.');
+                              continue;
+                            }
+                            final aFeet = double.tryParse(parts[0]);
+                            final resistance = double.tryParse(parts[1]);
+                            if (aFeet == null || resistance == null) {
+                              newSkipped.add('Row ${i + 1}: non-numeric value.');
+                              continue;
+                            }
+                            if (aFeet <= 0 || resistance <= 0) {
+                              newSkipped.add('Row ${i + 1}: values must be > 0.');
+                              continue;
+                            }
+                            final aMeters = feetToMeters(aFeet);
+                            final k = _geometryFactorForArray(arrayType, aMeters);
+                            if (k <= 0) {
+                              newSkipped.add('Row ${i + 1}: geometry factor unavailable.');
+                              continue;
+                            }
+                            final rho = resistance * k;
+                            final notes = bulkNotesController.text.trim();
+                            final point = SpacingPoint.newPoint(
+                              arrayType: arrayType,
+                              aFeet: aFeet,
+                              rhoAppOhmM: rho,
+                              direction: selectedDirection,
+                              spacingMeters: aMeters,
+                              notes: notes.isEmpty ? '${selectedDirection.label} bulk' : notes,
+                            );
+                            notifier.addPoint(point);
+                            added++;
+                          }
+                          setState(() {
+                            lastAdded = added;
+                            skippedMessages = newSkipped;
+                            summary = 'Added ${added.toString()} row(s). Skipped ${newSkipped.length}.';
+                          });
+                        },
+                        child: const Text('Import'),
+                      ),
+                    ],
+                  ),
+                  if (summary != null) ...[
+                    const SizedBox(height: 12),
+                    Align(
+                      alignment: Alignment.centerLeft,
+                      child: Text(summary!, style: Theme.of(sheetCtx).textTheme.bodySmall),
+                    ),
+                    if (skippedMessages.isNotEmpty)
+                      ...skippedMessages.map(
+                        (msg) => Align(
+                          alignment: Alignment.centerLeft,
+                          child: Text(
+                            '• ' + msg,
+                            style: Theme.of(sheetCtx)
+                                .textTheme
+                                .bodySmall
+                                ?.copyWith(color: Theme.of(sheetCtx).colorScheme.error),
+                          ),
+                        ),
+                      ),
+                  ],
+                ],
+              ),
+            );
+          },
+        );
+      },
+    );
+  }
+}
+
+double _geometryFactorForArray(ArrayType arrayType, double spacingMeters) {
+  if (spacingMeters <= 0) {
+    return 0;
+  }
+  switch (arrayType) {
+    case ArrayType.wenner:
+      return geom.geometryFactor(
+        array: geom.GeometryArray.wenner,
+        spacing: spacingMeters,
+      );
+    case ArrayType.schlumberger:
+      final mn = spacingMeters / 3;
+      return geom.geometryFactor(
+        array: geom.GeometryArray.schlumberger,
+        spacing: spacingMeters,
+        mn: mn,
+      );
+    case ArrayType.dipoleDipole:
+    case ArrayType.poleDipole:
+    case ArrayType.custom:
+      return 2 * math.pi * spacingMeters;
   }
 }

--- a/lib/ui/widgets/point_details_sheet.dart
+++ b/lib/ui/widgets/point_details_sheet.dart
@@ -33,6 +33,8 @@ class PointDetailsSheet extends ConsumerWidget {
             Text('Voltage: ${point.voltageV!.toStringAsFixed(3)} V'),
           if (point.currentA != null)
             Text('Current: ${point.currentA!.toStringAsFixed(3)} A'),
+          if (point.note != null && point.note!.isNotEmpty)
+            Text('Notes: ${point.note}'),
           if (point.rhoFromVi != null)
             Text('ρ (from V/I): ${point.rhoFromVi!.toStringAsFixed(2)} Ω·m'),
           if (diffPercent != null)

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1,9 +1,11 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:ves_qc/main.dart' as app;
+
+import 'package:ves_qc/main.dart';
 
 void main() {
   testWidgets('ResiCheck boots and shows Add Point action', (tester) async {
-    app.main();
+    await tester.pumpWidget(const ProviderScope(child: ResiCheckApp()));
     await tester.pumpAndSettle();
     expect(find.textContaining('Add Point'), findsOneWidget);
   });


### PR DESCRIPTION
## Summary
- update `SpacingPoint` to retain both feet/metre spacing, compute geometry-factor conversions, and carry optional notes for reporting
- replace the manual entry dialog with an A-spacing (ft) driven workflow that can derive resistivity/resistance, capture notes, and supports bulk paste imports with per-orientation tagging
- propagate geometry-factor math through CSV IO and surface notes inside the point detail sheet while refreshing the README and widget smoke test

## Testing
- not run (CI environment does not include Flutter/Dart SDK)

------
https://chatgpt.com/codex/tasks/task_e_68deb0866a88832eb50cf2c9cc3bfaf9