### PR TITLE
feat: add project workflow shell and exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,17 @@
 
 ResiCheck (formerly VES QC) is a field-ready, offline-first Flutter companion for geophysicists validating 1-D ERT/VES soundings in real time. It focuses on quick situational awareness, defensive QA, and rapid iteration while staying lightweight for remote use.
 
+## Project workflow (PR 026)
+
+The project workspace now provides autosaved project directories under `ResiCheckProjects/<ProjectName>/` with a left-pane plotting canvas and right-pane data entry table optimised for tablet number pads. Each project stores canonical `a` spacings, per-site metadata (power, stacks, soil, moisture), and dual-orientation readings (Direction A/B). Key capabilities include:
+
+- Live log–log apparent resistivity charts with site-average and template ghost curves (static JSON, no AI dependencies).
+- Deterministic QC flags (outlier cap, %SD gate, anisotropy ratio, log-jump) plus a depth cue sketch using DOI ≈ 0.5a.
+- Autosave every 10 s with undo/redo history, keyboard shortcuts (`Ctrl+S`, `Ctrl+E`, `N`, `F`, `X`) and a session-wide re-read history per spacing.
+- Timestamped CSV and Surfer `.DAT` exports saved beneath each project's `exports/` folder.
+
+A sample project (`assets/samples/sample_project.resicheck.json`) and ghost curve library (`assets/templates/ghost_curves.json`) are bundled for quick onboarding and offline validation.
+
 ## Repository layout
 
 ```

--- a/assets/samples/sample_project.resicheck.json
+++ b/assets/samples/sample_project.resicheck.json
@@ -1,0 +1,90 @@
+{
+  "schema_version": "1.1.0",
+  "project_id": "demo-12345",
+  "project_name": "Sample Training Project",
+  "array_type": "wenner",
+  "canonical_spacings_ft": [2.5, 5, 10, 20, 40, 60],
+  "default_power_ma": 0.5,
+  "default_stacks": 4,
+  "sites": [
+    {
+      "site_id": "TestLocation1",
+      "display_name": "Test Location 1",
+      "power_ma": 0.5,
+      "stacks": 4,
+      "soil": "mixed",
+      "moisture": "normal",
+      "spacings": [
+        {
+          "spacing_ft": 2.5,
+          "orientation_a": {
+            "orientation": "a",
+            "label": "N–S",
+            "samples": [
+              {
+                "timestamp": "2024-01-01T12:00:00.000Z",
+                "resistance_ohm": 48.0,
+                "sd_pct": 4.5,
+                "note": "",
+                "is_bad": false
+              }
+            ]
+          },
+          "orientation_b": {
+            "orientation": "b",
+            "label": "W–E",
+            "samples": [
+              {
+                "timestamp": "2024-01-01T12:02:00.000Z",
+                "resistance_ohm": 52.0,
+                "sd_pct": 5.0,
+                "note": "",
+                "is_bad": false
+              }
+            ]
+          }
+        },
+        {
+          "spacing_ft": 5.0,
+          "orientation_a": {
+            "orientation": "a",
+            "label": "N–S",
+            "samples": [
+              {
+                "timestamp": "2024-01-01T12:05:00.000Z",
+                "resistance_ohm": 55.0,
+                "sd_pct": 6.0,
+                "note": "",
+                "is_bad": false
+              }
+            ]
+          },
+          "orientation_b": {
+            "orientation": "b",
+            "label": "W–E",
+            "samples": [
+              {
+                "timestamp": "2024-01-01T12:06:00.000Z",
+                "resistance_ohm": 59.0,
+                "sd_pct": 6.5,
+                "note": "",
+                "is_bad": false
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "site_id": "TestLocation2",
+      "display_name": "Test Location 2",
+      "power_ma": 0.5,
+      "stacks": 4,
+      "soil": "clay",
+      "moisture": "wet",
+      "spacings": []
+    }
+  ],
+  "created_at": "2024-01-01T00:00:00.000Z",
+  "updated_at": "2024-01-01T00:00:00.000Z"
+}

--- a/assets/templates/ghost_curves.json
+++ b/assets/templates/ghost_curves.json
@@ -1,0 +1,44 @@
+[
+  {
+    "id": "wet_clay",
+    "name": "Wet clayey soil",
+    "soil": "clay",
+    "moisture": "wet",
+    "points": [
+      { "spacing_ft": 2.5, "rho_ohm_m": 25 },
+      { "spacing_ft": 5, "rho_ohm_m": 28 },
+      { "spacing_ft": 10, "rho_ohm_m": 32 },
+      { "spacing_ft": 20, "rho_ohm_m": 35 },
+      { "spacing_ft": 40, "rho_ohm_m": 38 },
+      { "spacing_ft": 60, "rho_ohm_m": 40 }
+    ]
+  },
+  {
+    "id": "dry_sand",
+    "name": "Dry sand/gravel",
+    "soil": "gravelly",
+    "moisture": "dry",
+    "points": [
+      { "spacing_ft": 2.5, "rho_ohm_m": 120 },
+      { "spacing_ft": 5, "rho_ohm_m": 150 },
+      { "spacing_ft": 10, "rho_ohm_m": 180 },
+      { "spacing_ft": 20, "rho_ohm_m": 210 },
+      { "spacing_ft": 40, "rho_ohm_m": 240 },
+      { "spacing_ft": 60, "rho_ohm_m": 260 }
+    ]
+  },
+  {
+    "id": "normal_mixed",
+    "name": "Normal mixed soil",
+    "soil": "mixed",
+    "moisture": "normal",
+    "points": [
+      { "spacing_ft": 2.5, "rho_ohm_m": 60 },
+      { "spacing_ft": 5, "rho_ohm_m": 65 },
+      { "spacing_ft": 10, "rho_ohm_m": 70 },
+      { "spacing_ft": 20, "rho_ohm_m": 80 },
+      { "spacing_ft": 40, "rho_ohm_m": 90 },
+      { "spacing_ft": 60, "rho_ohm_m": 95 }
+    ]
+  }
+]

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-import 'ui/screens/home_screen.dart';
+import 'ui/project_workflow/home_page.dart';
 
 void main() {
   WidgetsFlutterBinding.ensureInitialized();
@@ -19,7 +19,7 @@ class ResiCheckApp extends StatelessWidget {
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
         useMaterial3: true,
       ),
-      home: const HomeScreen(),
+      home: const ProjectWorkflowHomePage(),
     );
   }
 }

--- a/lib/models/calc.dart
+++ b/lib/models/calc.dart
@@ -1,0 +1,120 @@
+import 'dart:math' as math;
+
+class QcConfig {
+  const QcConfig({
+    this.outlierCapOhm = 100000,
+    this.sdThresholdPercent = 15,
+    this.anisotropyRatioThreshold = 3,
+    this.jumpThresholdLog10 = 0.35,
+  });
+
+  final double outlierCapOhm;
+  final double sdThresholdPercent;
+  final double anisotropyRatioThreshold;
+  final double jumpThresholdLog10;
+}
+
+double feetToMeters(double feet) => feet * 0.3048;
+
+double metersToFeet(double meters) => meters / 0.3048;
+
+double rhoAWenner(double spacingFeet, double resistanceOhm) {
+  final spacingMeters = feetToMeters(spacingFeet);
+  return 2 * math.pi * spacingMeters * resistanceOhm;
+}
+
+double? averageApparentResistivity(
+  double spacingFeet,
+  Iterable<double?> resistances,
+) {
+  final valid = resistances.whereType<double>().toList();
+  if (valid.isEmpty) {
+    return null;
+  }
+  final rhoValues =
+      valid.map((resistance) => rhoAWenner(spacingFeet, resistance)).toList();
+  final sum = rhoValues.reduce((a, b) => a + b);
+  return sum / rhoValues.length;
+}
+
+double? anisotropyRatio(double? rhoA, double? rhoB) {
+  if (rhoA == null || rhoB == null) {
+    return null;
+  }
+  final maxVal = math.max(rhoA.abs(), rhoB.abs());
+  final minVal = math.min(rhoA.abs(), rhoB.abs());
+  if (minVal == 0) {
+    return null;
+  }
+  return maxVal / minVal;
+}
+
+class QcFlags {
+  const QcFlags({
+    this.outlier = false,
+    this.highVariance = false,
+    this.anisotropy = false,
+    this.jump = false,
+  });
+
+  final bool outlier;
+  final bool highVariance;
+  final bool anisotropy;
+  final bool jump;
+
+  bool get hasAny => outlier || highVariance || anisotropy || jump;
+}
+
+QcFlags evaluateQc({
+  required double spacingFeet,
+  required double? resistanceA,
+  required double? resistanceB,
+  required double? sdA,
+  required double? sdB,
+  required QcConfig config,
+  double? previousRho,
+}) {
+  final rhoA =
+      resistanceA == null ? null : rhoAWenner(spacingFeet, resistanceA);
+  final rhoB =
+      resistanceB == null ? null : rhoAWenner(spacingFeet, resistanceB);
+  final ratio = anisotropyRatio(rhoA, rhoB);
+  final latestRho = _averageNullable([rhoA, rhoB]);
+
+  final outlier = (resistanceA != null && resistanceA.abs() > config.outlierCapOhm) ||
+      (resistanceB != null && resistanceB.abs() > config.outlierCapOhm);
+  final highVariance = ((sdA ?? 0) > config.sdThresholdPercent) ||
+      ((sdB ?? 0) > config.sdThresholdPercent);
+  final anisotropy = ratio != null && ratio > config.anisotropyRatioThreshold;
+
+  bool jump = false;
+  if (previousRho != null && latestRho != null && previousRho > 0 && latestRho > 0) {
+    final jumpMagnitude = (math.log(previousRho) / math.ln10) -
+        (math.log(latestRho) / math.ln10);
+    jump = jumpMagnitude.abs() > config.jumpThresholdLog10;
+  }
+
+  return QcFlags(
+    outlier: outlier,
+    highVariance: highVariance,
+    anisotropy: anisotropy,
+    jump: jump,
+  );
+}
+
+List<double> computeDepthCueFeet(List<double> spacingsFeet) {
+  return spacingsFeet.map((spacing) => spacing * 0.5).toList();
+}
+
+List<double> computeDepthCueMeters(List<double> spacingsFeet) {
+  return computeDepthCueFeet(spacingsFeet).map(feetToMeters).toList();
+}
+
+double? _averageNullable(List<double?> values) {
+  final filtered = values.whereType<double>().toList();
+  if (filtered.isEmpty) {
+    return null;
+  }
+  final sum = filtered.reduce((a, b) => a + b);
+  return sum / filtered.length;
+}

--- a/lib/models/direction_reading.dart
+++ b/lib/models/direction_reading.dart
@@ -1,0 +1,196 @@
+import 'dart:convert';
+
+import 'package:collection/collection.dart';
+
+import 'calc.dart';
+
+enum OrientationKind { a, b }
+
+extension OrientationKindLabel on OrientationKind {
+  String get defaultLabel {
+    switch (this) {
+      case OrientationKind.a:
+        return 'Direction A';
+      case OrientationKind.b:
+        return 'Direction B';
+    }
+  }
+}
+
+class DirectionReadingSample {
+  DirectionReadingSample({
+    required this.timestamp,
+    this.resistanceOhm,
+    this.standardDeviationPercent,
+    this.note = '',
+    this.isBad = false,
+  });
+
+  factory DirectionReadingSample.fromJson(Map<String, dynamic> json) {
+    return DirectionReadingSample(
+      timestamp: DateTime.parse(json['timestamp'] as String),
+      resistanceOhm: (json['resistance_ohm'] as num?)?.toDouble(),
+      standardDeviationPercent: (json['sd_pct'] as num?)?.toDouble(),
+      note: json['note'] as String? ?? '',
+      isBad: json['is_bad'] as bool? ?? false,
+    );
+  }
+
+  final DateTime timestamp;
+  final double? resistanceOhm;
+  final double? standardDeviationPercent;
+  final bool isBad;
+  final String note;
+
+  double? apparentResistivityOhmM(double spacingFeet) {
+    if (resistanceOhm == null) {
+      return null;
+    }
+    return rhoAWenner(spacingFeet, resistanceOhm!);
+  }
+
+  DirectionReadingSample copyWith({
+    DateTime? timestamp,
+    Object? resistanceOhm = _unset,
+    Object? standardDeviationPercent = _unset,
+    bool? isBad,
+    String? note,
+  }) {
+    return DirectionReadingSample(
+      timestamp: timestamp ?? this.timestamp,
+      resistanceOhm: identical(resistanceOhm, _unset)
+          ? this.resistanceOhm
+          : (resistanceOhm as double?),
+      standardDeviationPercent: identical(standardDeviationPercent, _unset)
+          ? this.standardDeviationPercent
+          : (standardDeviationPercent as double?),
+      isBad: isBad ?? this.isBad,
+      note: note ?? this.note,
+    );
+  }
+
+  Map<String, dynamic> toJson() => <String, dynamic>{
+        'timestamp': timestamp.toIso8601String(),
+        'resistance_ohm': resistanceOhm,
+        'sd_pct': standardDeviationPercent,
+        'note': note,
+        'is_bad': isBad,
+      };
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is DirectionReadingSample &&
+        other.timestamp == timestamp &&
+        other.resistanceOhm == resistanceOhm &&
+        other.standardDeviationPercent == standardDeviationPercent &&
+        other.note == note &&
+        other.isBad == isBad;
+  }
+
+  @override
+  int get hashCode => Object.hash(
+        timestamp,
+        resistanceOhm,
+        standardDeviationPercent,
+        note,
+        isBad,
+      );
+
+  static const _unset = Object();
+}
+
+class DirectionReadingHistory {
+  DirectionReadingHistory({
+    required this.orientation,
+    required this.label,
+    List<DirectionReadingSample>? samples,
+  }) : samples = List.unmodifiable(samples ?? const <DirectionReadingSample>[]);
+
+  factory DirectionReadingHistory.fromJson(Map<String, dynamic> json) {
+    return DirectionReadingHistory(
+      orientation:
+          OrientationKind.values.byName(json['orientation'] as String),
+      label: json['label'] as String? ??
+          OrientationKind.values
+              .byName(json['orientation'] as String)
+              .defaultLabel,
+      samples: (json['samples'] as List<dynamic>? ?? const [])
+          .map((dynamic e) =>
+              DirectionReadingSample.fromJson(e as Map<String, dynamic>))
+          .toList(),
+    );
+  }
+
+  final OrientationKind orientation;
+  final String label;
+  final List<DirectionReadingSample> samples;
+
+  DirectionReadingSample? get latest => samples.lastWhereOrNull((sample) {
+        if (sample.isBad) {
+          return false;
+        }
+        return sample.resistanceOhm != null;
+      }) ?? samples.lastOrNull;
+
+  bool get hasValidSample => samples.any((sample) => !sample.isBad);
+
+  DirectionReadingHistory addSample(DirectionReadingSample sample) {
+    final updated = [...samples, sample];
+    return DirectionReadingHistory(
+      orientation: orientation,
+      label: label,
+      samples: updated,
+    );
+  }
+
+  DirectionReadingHistory updateLatest(DirectionReadingSample Function(DirectionReadingSample current) updater) {
+    if (samples.isEmpty) {
+      return addSample(updater(DirectionReadingSample(timestamp: DateTime.now())));
+    }
+    final updatedSamples = [...samples];
+    updatedSamples[updatedSamples.length - 1] =
+        updater(updatedSamples.last);
+    return DirectionReadingHistory(
+      orientation: orientation,
+      label: label,
+      samples: updatedSamples,
+    );
+  }
+
+  DirectionReadingHistory copyWith({
+    String? label,
+    List<DirectionReadingSample>? samples,
+  }) {
+    return DirectionReadingHistory(
+      orientation: orientation,
+      label: label ?? this.label,
+      samples: samples ?? this.samples,
+    );
+  }
+
+  Map<String, dynamic> toJson() => <String, dynamic>{
+        'orientation': orientation.name,
+        'label': label,
+        'samples': samples.map((e) => e.toJson()).toList(),
+      };
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is DirectionReadingHistory &&
+        other.orientation == orientation &&
+        other.label == label &&
+        const ListEquality<DirectionReadingSample>().equals(
+          other.samples,
+          samples,
+        );
+  }
+
+  @override
+  int get hashCode =>
+      Object.hash(orientation, label, const ListEquality().hash(samples));
+
+  @override
+  String toString() => jsonEncode(toJson());
+}

--- a/lib/models/project.dart
+++ b/lib/models/project.dart
@@ -1,0 +1,217 @@
+import 'dart:convert';
+
+import 'package:collection/collection.dart';
+
+import 'enums.dart';
+import 'site.dart';
+
+const currentProjectSchemaVersion = '1.1.0';
+
+class ProjectRecord {
+  ProjectRecord({
+    required this.projectId,
+    required this.projectName,
+    required this.arrayType,
+    required List<double> canonicalSpacingsFeet,
+    required this.defaultPowerMilliAmps,
+    required this.defaultStacks,
+    List<SiteRecord>? sites,
+    String? schemaVersion,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+  })  : canonicalSpacingsFeet = List.unmodifiable(canonicalSpacingsFeet),
+        sites = List.unmodifiable(sites ?? const <SiteRecord>[]),
+        schemaVersion = schemaVersion ?? currentProjectSchemaVersion,
+        createdAt = createdAt ?? DateTime.now(),
+        updatedAt = updatedAt ?? DateTime.now();
+
+  factory ProjectRecord.newProject({
+    required String projectId,
+    required String projectName,
+    ArrayType arrayType = ArrayType.wenner,
+    List<double>? canonicalSpacingsFeet,
+  }) {
+    return ProjectRecord(
+      projectId: projectId,
+      projectName: projectName,
+      arrayType: arrayType,
+      canonicalSpacingsFeet: canonicalSpacingsFeet ??
+          const [2.5, 5, 10, 20, 40, 60],
+      defaultPowerMilliAmps: 0.5,
+      defaultStacks: 4,
+    );
+  }
+
+  factory ProjectRecord.fromJson(Map<String, dynamic> json) {
+    final migrated = ProjectSchemaMigration.migrate(json);
+    return ProjectRecord(
+      projectId: migrated['project_id'] as String,
+      projectName: migrated['project_name'] as String,
+      arrayType:
+          ArrayType.values.byName(migrated['array_type'] as String? ?? 'wenner'),
+      canonicalSpacingsFeet: (migrated['canonical_spacings_ft'] as List<dynamic>)
+          .map((dynamic e) => (e as num).toDouble())
+          .toList(),
+      defaultPowerMilliAmps:
+          (migrated['default_power_ma'] as num?)?.toDouble() ?? 0.5,
+      defaultStacks: migrated['default_stacks'] as int? ?? 4,
+      sites: (migrated['sites'] as List<dynamic>? ?? const [])
+          .map((dynamic e) => SiteRecord.fromJson(e as Map<String, dynamic>))
+          .toList(),
+      schemaVersion: migrated['schema_version'] as String?,
+      createdAt: DateTime.parse(migrated['created_at'] as String),
+      updatedAt: DateTime.parse(migrated['updated_at'] as String),
+    );
+  }
+
+  final String projectId;
+  final String projectName;
+  final ArrayType arrayType;
+  final List<double> canonicalSpacingsFeet;
+  final double defaultPowerMilliAmps;
+  final int defaultStacks;
+  final List<SiteRecord> sites;
+  final String schemaVersion;
+  final DateTime createdAt;
+  final DateTime updatedAt;
+
+  ProjectRecord copyWith({
+    String? projectId,
+    String? projectName,
+    ArrayType? arrayType,
+    List<double>? canonicalSpacingsFeet,
+    double? defaultPowerMilliAmps,
+    int? defaultStacks,
+    List<SiteRecord>? sites,
+    String? schemaVersion,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+  }) {
+    return ProjectRecord(
+      projectId: projectId ?? this.projectId,
+      projectName: projectName ?? this.projectName,
+      arrayType: arrayType ?? this.arrayType,
+      canonicalSpacingsFeet:
+          canonicalSpacingsFeet ?? this.canonicalSpacingsFeet,
+      defaultPowerMilliAmps: defaultPowerMilliAmps ?? this.defaultPowerMilliAmps,
+      defaultStacks: defaultStacks ?? this.defaultStacks,
+      sites: sites ?? this.sites,
+      schemaVersion: schemaVersion ?? this.schemaVersion,
+      createdAt: createdAt ?? this.createdAt,
+      updatedAt: updatedAt ?? DateTime.now(),
+    );
+  }
+
+  ProjectRecord addSite(SiteRecord site) {
+    final updated = [...sites, site];
+    return copyWith(sites: updated);
+  }
+
+  ProjectRecord updateSite(
+    String siteId,
+    SiteRecord Function(SiteRecord current) updater,
+  ) {
+    final updated = [...sites];
+    final index = updated.indexWhere((element) => element.siteId == siteId);
+    if (index == -1) {
+      throw ArgumentError('Site $siteId not found');
+    }
+    updated[index] = updater(updated[index]);
+    return copyWith(sites: updated);
+  }
+
+  ProjectRecord upsertSite(SiteRecord site) {
+    final updated = [...sites];
+    final index = updated.indexWhere((element) => element.siteId == site.siteId);
+    if (index >= 0) {
+      updated[index] = site;
+    } else {
+      updated.add(site);
+    }
+    return copyWith(sites: updated);
+  }
+
+  SiteRecord? siteById(String siteId) {
+    return sites.firstWhereOrNull((site) => site.siteId == siteId);
+  }
+
+  Map<String, dynamic> toJson() => <String, dynamic>{
+        'schema_version': schemaVersion,
+        'project_id': projectId,
+        'project_name': projectName,
+        'array_type': arrayType.name,
+        'canonical_spacings_ft': canonicalSpacingsFeet,
+        'default_power_ma': defaultPowerMilliAmps,
+        'default_stacks': defaultStacks,
+        'sites': sites.map((e) => e.toJson()).toList(),
+        'created_at': createdAt.toIso8601String(),
+        'updated_at': updatedAt.toIso8601String(),
+      };
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is ProjectRecord &&
+        projectId == other.projectId &&
+        projectName == other.projectName &&
+        arrayType == other.arrayType &&
+        const ListEquality<double>()
+            .equals(canonicalSpacingsFeet, other.canonicalSpacingsFeet) &&
+        defaultPowerMilliAmps == other.defaultPowerMilliAmps &&
+        defaultStacks == other.defaultStacks &&
+        const ListEquality<SiteRecord>().equals(sites, other.sites);
+  }
+
+  @override
+  int get hashCode => Object.hash(
+        projectId,
+        projectName,
+        arrayType,
+        const ListEquality().hash(canonicalSpacingsFeet),
+        defaultPowerMilliAmps,
+        defaultStacks,
+        const ListEquality().hash(sites),
+      );
+
+  @override
+  String toString() => jsonEncode(toJson());
+}
+
+class ProjectSchemaMigration {
+  static Map<String, dynamic> migrate(Map<String, dynamic> json) {
+    final schemaVersion = json['schema_version'] as String? ?? '1.0.0';
+    if (schemaVersion == currentProjectSchemaVersion) {
+      return json;
+    }
+
+    final migrated = Map<String, dynamic>.from(json);
+    migrated['schema_version'] = currentProjectSchemaVersion;
+    migrated['created_at'] =
+        (json['created_at'] as String? ?? DateTime.now().toIso8601String());
+    migrated['updated_at'] =
+        (json['updated_at'] as String? ?? DateTime.now().toIso8601String());
+    migrated['canonical_spacings_ft'] =
+        (json['canonical_spacings_ft'] as List<dynamic>? ??
+                (json['spacings_ft'] as List<dynamic>? ?? const [2.5, 5, 10]))
+            .map((dynamic e) => (e as num).toDouble())
+            .toList();
+    migrated['default_power_ma'] =
+        (json['default_power_ma'] as num?)?.toDouble() ?? 0.5;
+    migrated['default_stacks'] = json['default_stacks'] as int? ?? 4;
+    return migrated;
+  }
+}
+
+class ProjectSummary {
+  ProjectSummary({
+    required this.projectId,
+    required this.projectName,
+    required this.lastOpened,
+    required this.path,
+  });
+
+  final String projectId;
+  final String projectName;
+  final DateTime lastOpened;
+  final String path;
+}

--- a/lib/models/site.dart
+++ b/lib/models/site.dart
@@ -1,0 +1,303 @@
+import 'package:collection/collection.dart';
+
+import 'calc.dart';
+import 'direction_reading.dart';
+
+enum SoilType {
+  unknown,
+  clay,
+  sandy,
+  gravelly,
+  mixed,
+}
+
+extension SoilTypeLabel on SoilType {
+  String get label {
+    switch (this) {
+      case SoilType.unknown:
+        return 'Unknown';
+      case SoilType.clay:
+        return 'Clay / Clayey';
+      case SoilType.sandy:
+        return 'Sand / Sandy';
+      case SoilType.gravelly:
+        return 'Gravel / Coarse';
+      case SoilType.mixed:
+        return 'Mixed';
+    }
+  }
+}
+
+enum MoistureLevel { dry, normal, wet }
+
+extension MoistureLevelLabel on MoistureLevel {
+  String get label {
+    switch (this) {
+      case MoistureLevel.dry:
+        return 'Dry';
+      case MoistureLevel.normal:
+        return 'Normal';
+      case MoistureLevel.wet:
+        return 'Wet';
+    }
+  }
+}
+
+class SpacingRecord {
+  SpacingRecord({
+    required this.spacingFeet,
+    required DirectionReadingHistory orientationA,
+    required DirectionReadingHistory orientationB,
+  })  : orientationA = orientationA,
+        orientationB = orientationB;
+
+  factory SpacingRecord.seed({
+    required double spacingFeet,
+    String? orientationALabel,
+    String? orientationBLabel,
+  }) {
+    return SpacingRecord(
+      spacingFeet: spacingFeet,
+      orientationA: DirectionReadingHistory(
+        orientation: OrientationKind.a,
+        label: orientationALabel ?? OrientationKind.a.defaultLabel,
+      ),
+      orientationB: DirectionReadingHistory(
+        orientation: OrientationKind.b,
+        label: orientationBLabel ?? OrientationKind.b.defaultLabel,
+      ),
+    );
+  }
+
+  factory SpacingRecord.fromJson(Map<String, dynamic> json) {
+    return SpacingRecord(
+      spacingFeet: (json['spacing_ft'] as num).toDouble(),
+      orientationA: DirectionReadingHistory.fromJson(
+        json['orientation_a'] as Map<String, dynamic>,
+      ),
+      orientationB: DirectionReadingHistory.fromJson(
+        json['orientation_b'] as Map<String, dynamic>,
+      ),
+    );
+  }
+
+  final double spacingFeet;
+  final DirectionReadingHistory orientationA;
+  final DirectionReadingHistory orientationB;
+
+  double get tapeInsideFeet => spacingFeet / 2;
+
+  double get tapeOutsideFeet => spacingFeet * 1.5;
+
+  double get tapeInsideMeters => feetToMeters(tapeInsideFeet);
+
+  double get tapeOutsideMeters => feetToMeters(tapeOutsideFeet);
+
+  DirectionReadingHistory historyFor(OrientationKind orientation) {
+    switch (orientation) {
+      case OrientationKind.a:
+        return orientationA;
+      case OrientationKind.b:
+        return orientationB;
+    }
+  }
+
+  SpacingRecord updateHistory(
+    OrientationKind orientation,
+    DirectionReadingHistory history,
+  ) {
+    switch (orientation) {
+      case OrientationKind.a:
+        return copyWith(orientationA: history);
+      case OrientationKind.b:
+        return copyWith(orientationB: history);
+    }
+  }
+
+  SpacingRecord renameOrientation(
+    OrientationKind orientation,
+    String label,
+  ) {
+    switch (orientation) {
+      case OrientationKind.a:
+        return copyWith(
+          orientationA: orientationA.copyWith(label: label),
+        );
+      case OrientationKind.b:
+        return copyWith(
+          orientationB: orientationB.copyWith(label: label),
+        );
+    }
+  }
+
+  SpacingRecord copyWith({
+    double? spacingFeet,
+    DirectionReadingHistory? orientationA,
+    DirectionReadingHistory? orientationB,
+  }) {
+    return SpacingRecord(
+      spacingFeet: spacingFeet ?? this.spacingFeet,
+      orientationA: orientationA ?? this.orientationA,
+      orientationB: orientationB ?? this.orientationB,
+    );
+  }
+
+  Map<String, dynamic> toJson() => <String, dynamic>{
+        'spacing_ft': spacingFeet,
+        'orientation_a': orientationA.toJson(),
+        'orientation_b': orientationB.toJson(),
+      };
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is SpacingRecord &&
+        spacingFeet == other.spacingFeet &&
+        orientationA == other.orientationA &&
+        orientationB == other.orientationB;
+  }
+
+  @override
+  int get hashCode => Object.hash(spacingFeet, orientationA, orientationB);
+}
+
+class SiteRecord {
+  SiteRecord({
+    required this.siteId,
+    required this.displayName,
+    this.powerMilliAmps = 0.5,
+    this.stacks = 4,
+    this.soil = SoilType.unknown,
+    this.moisture = MoistureLevel.normal,
+    List<SpacingRecord>? spacings,
+  }) : spacings = List.unmodifiable(spacings ?? const <SpacingRecord>[]);
+
+  factory SiteRecord.fromJson(Map<String, dynamic> json) {
+    return SiteRecord(
+      siteId: json['site_id'] as String,
+      displayName: json['display_name'] as String? ?? json['site_id'] as String,
+      powerMilliAmps: (json['power_ma'] as num?)?.toDouble() ?? 0.5,
+      stacks: json['stacks'] as int? ?? 4,
+      soil: SoilType.values.byName(json['soil'] as String? ?? 'unknown'),
+      moisture: MoistureLevel.values
+          .byName(json['moisture'] as String? ?? MoistureLevel.normal.name),
+      spacings: (json['spacings'] as List<dynamic>? ?? const [])
+          .map((dynamic e) =>
+              SpacingRecord.fromJson(e as Map<String, dynamic>))
+          .toList(),
+    );
+  }
+
+  final String siteId;
+  final String displayName;
+  final double powerMilliAmps;
+  final int stacks;
+  final SoilType soil;
+  final MoistureLevel moisture;
+  final List<SpacingRecord> spacings;
+
+  SpacingRecord? spacing(double spacingFeet) {
+    return spacings
+        .firstWhereOrNull((element) => element.spacingFeet == spacingFeet);
+  }
+
+  SiteRecord upsertSpacing(SpacingRecord record) {
+    final updated = [...spacings];
+    final index = updated.indexWhere(
+      (element) => element.spacingFeet == record.spacingFeet,
+    );
+    if (index >= 0) {
+      updated[index] = record;
+    } else {
+      updated.add(record);
+      updated.sort((a, b) => a.spacingFeet.compareTo(b.spacingFeet));
+    }
+    return copyWith(spacings: updated);
+  }
+
+  SiteRecord updateSpacing(
+    double spacingFeet,
+    SpacingRecord Function(SpacingRecord current) updater,
+  ) {
+    final existing = spacing(spacingFeet);
+    final updatedRecord = updater(
+      existing ??
+          SpacingRecord.seed(
+            spacingFeet: spacingFeet,
+          ),
+    );
+    return upsertSpacing(updatedRecord);
+  }
+
+  SiteRecord updateMetadata({
+    String? displayName,
+    double? powerMilliAmps,
+    int? stacks,
+    SoilType? soil,
+    MoistureLevel? moisture,
+  }) {
+    return SiteRecord(
+      siteId: siteId,
+      displayName: displayName ?? this.displayName,
+      powerMilliAmps: powerMilliAmps ?? this.powerMilliAmps,
+      stacks: stacks ?? this.stacks,
+      soil: soil ?? this.soil,
+      moisture: moisture ?? this.moisture,
+      spacings: spacings,
+    );
+  }
+
+  Map<String, dynamic> toJson() => <String, dynamic>{
+        'site_id': siteId,
+        'display_name': displayName,
+        'power_ma': powerMilliAmps,
+        'stacks': stacks,
+        'soil': soil.name,
+        'moisture': moisture.name,
+        'spacings': spacings.map((e) => e.toJson()).toList(),
+      };
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is SiteRecord &&
+        siteId == other.siteId &&
+        displayName == other.displayName &&
+        powerMilliAmps == other.powerMilliAmps &&
+        stacks == other.stacks &&
+        soil == other.soil &&
+        moisture == other.moisture &&
+        const ListEquality<SpacingRecord>().equals(spacings, other.spacings);
+  }
+
+  @override
+  int get hashCode => Object.hash(
+        siteId,
+        displayName,
+        powerMilliAmps,
+        stacks,
+        soil,
+        moisture,
+        const ListEquality().hash(spacings),
+      );
+
+  SiteRecord copyWith({
+    String? siteId,
+    String? displayName,
+    double? powerMilliAmps,
+    int? stacks,
+    SoilType? soil,
+    MoistureLevel? moisture,
+    List<SpacingRecord>? spacings,
+  }) {
+    return SiteRecord(
+      siteId: siteId ?? this.siteId,
+      displayName: displayName ?? this.displayName,
+      powerMilliAmps: powerMilliAmps ?? this.powerMilliAmps,
+      stacks: stacks ?? this.stacks,
+      soil: soil ?? this.soil,
+      moisture: moisture ?? this.moisture,
+      spacings: spacings ?? this.spacings,
+    );
+  }
+}

--- a/lib/services/export_service.dart
+++ b/lib/services/export_service.dart
@@ -1,0 +1,116 @@
+import 'dart:io';
+
+import 'package:csv/csv.dart';
+
+import '../models/calc.dart';
+import '../models/direction_reading.dart';
+import '../models/project.dart';
+import '../models/site.dart';
+import 'storage_service.dart';
+
+class ExportService {
+  ExportService(this.storageService);
+
+  final ProjectStorageService storageService;
+
+  Future<File> exportFieldCsv(ProjectRecord project, SiteRecord site) async {
+    final rows = <List<dynamic>>[
+      [
+        'site_id',
+        'orientation',
+        'a_ft',
+        'inside_ft',
+        'outside_ft',
+        'power_ma',
+        'stacks',
+        'resistance_ohm',
+        'sd_pct',
+        'rhoa_ohm_m',
+        'note',
+        'is_bad',
+      ],
+    ];
+
+    final spacings = [...site.spacings]
+      ..sort((a, b) => a.spacingFeet.compareTo(b.spacingFeet));
+    for (final spacing in spacings) {
+      rows.add(_rowForSpacing(site, spacing, spacing.orientationA));
+      rows.add(_rowForSpacing(site, spacing, spacing.orientationB));
+    }
+
+    final converter = const ListToCsvConverter();
+    final csv = converter.convert(rows);
+    final file = await storageService.ensureExportFile(
+      project,
+      '${project.projectId}_${_slug(project.projectName)}_${site.siteId}_field',
+      'csv',
+    );
+    await file.writeAsString(csv);
+    return file;
+  }
+
+  Future<File> exportSurferDat(ProjectRecord project, SiteRecord site) async {
+    final buffer = StringBuffer();
+    buffer.writeln('# ResiCheck Surfer DAT export');
+    buffer.writeln('# project_id=${project.projectId}');
+    buffer.writeln('# site_id=${site.siteId}');
+    buffer.writeln('a_ft,orientation,resistance_ohm,rhoa_ohm_m,sd_pct,is_bad');
+    final spacings = [...site.spacings]
+      ..sort((a, b) => a.spacingFeet.compareTo(b.spacingFeet));
+    for (final spacing in spacings) {
+      buffer.writeln(_lineForSpacing(spacing, spacing.orientationA));
+      buffer.writeln(_lineForSpacing(spacing, spacing.orientationB));
+    }
+    final file = await storageService.ensureExportFile(
+      project,
+      '${project.projectId}_${_slug(project.projectName)}_${site.siteId}_surfer',
+      'dat',
+    );
+    await file.writeAsString(buffer.toString());
+    return file;
+  }
+
+  List<dynamic> _rowForSpacing(
+    SiteRecord site,
+    SpacingRecord spacing,
+    DirectionReadingHistory history,
+  ) {
+    final sample = history.latest;
+    final resistance = sample?.resistanceOhm;
+    final rho = resistance == null
+        ? null
+        : rhoAWenner(spacing.spacingFeet, resistance);
+    return [
+      site.siteId,
+      history.label,
+      spacing.spacingFeet,
+      spacing.tapeInsideFeet,
+      spacing.tapeOutsideFeet,
+      site.powerMilliAmps,
+      site.stacks,
+      resistance,
+      sample?.standardDeviationPercent,
+      rho,
+      sample?.note ?? '',
+      sample?.isBad ?? false,
+    ];
+  }
+
+  String _lineForSpacing(
+    SpacingRecord spacing,
+    DirectionReadingHistory history,
+  ) {
+    final sample = history.latest;
+    final resistance = sample?.resistanceOhm ?? 0;
+    final rho = rhoAWenner(spacing.spacingFeet, resistance);
+    final sd = sample?.standardDeviationPercent ?? 0;
+    final isBad = sample?.isBad ?? false;
+    return '${spacing.spacingFeet},${history.label},$resistance,$rho,$sd,${isBad ? 1 : 0}';
+  }
+
+  String _slug(String input) {
+    final trimmed = input.trim();
+    final sanitized = trimmed.replaceAll(RegExp(r'[^A-Za-z0-9-_]'), '_');
+    return sanitized.isEmpty ? 'project' : sanitized;
+  }
+}

--- a/lib/services/storage_service.dart
+++ b/lib/services/storage_service.dart
@@ -1,0 +1,206 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:intl/intl.dart';
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
+import 'package:uuid/uuid.dart';
+
+import '../models/project.dart';
+
+const _projectFileName = 'project.resicheck.json';
+const _exportsFolderName = 'exports';
+const _sitesFolderName = 'sites';
+
+class ProjectStorageService {
+  ProjectStorageService({Directory? overrideRoot}) : _overrideRoot = overrideRoot;
+
+  final Directory? _overrideRoot;
+  final _uuid = const Uuid();
+
+  Future<Directory> _ensureRoot() async {
+    if (_overrideRoot != null) {
+      if (!await _overrideRoot!.exists()) {
+        await _overrideRoot!.create(recursive: true);
+      }
+      return _overrideRoot!;
+    }
+    final docs = await getApplicationDocumentsDirectory();
+    final root = Directory(p.join(docs.path, 'ResiCheckProjects'));
+    if (!await root.exists()) {
+      await root.create(recursive: true);
+    }
+    return root;
+  }
+
+  Future<ProjectRecord> createProject(String name,
+      {List<double>? canonicalSpacingsFeet}) async {
+    final root = await _ensureRoot();
+    final projectId = _uuid.v4();
+    final safeName = _safeFolderName(name);
+    final dir = Directory(p.join(root.path, safeName));
+    if (!await dir.exists()) {
+      await dir.create(recursive: true);
+    }
+    final project = ProjectRecord.newProject(
+      projectId: projectId,
+      projectName: name,
+      canonicalSpacingsFeet: canonicalSpacingsFeet,
+    );
+    return saveProject(project, directoryOverride: dir);
+  }
+
+  Future<ProjectRecord?> loadProject(Directory directory) async {
+    final file = File(p.join(directory.path, _projectFileName));
+    if (!await file.exists()) {
+      return null;
+    }
+    final raw = await file.readAsString();
+    final json = jsonDecode(raw) as Map<String, dynamic>;
+    final record = ProjectRecord.fromJson(json);
+    return record.copyWith(updatedAt: DateTime.now());
+  }
+
+  Future<ProjectRecord> saveProject(
+    ProjectRecord project, {
+    Directory? directoryOverride,
+  }) async {
+    final root = await _ensureRoot();
+    final directory = directoryOverride ??
+        Directory(p.join(root.path, _safeFolderName(project.projectName)));
+    if (!await directory.exists()) {
+      await directory.create(recursive: true);
+    }
+    final updated = project.copyWith(updatedAt: DateTime.now());
+    final file = File(p.join(directory.path, _projectFileName));
+    await file.writeAsString(JsonEncoder.withIndent('  ').convert(updated.toJson()));
+    return updated;
+  }
+
+  Future<Directory> projectDirectory(ProjectRecord project) async {
+    final root = await _ensureRoot();
+    return Directory(p.join(root.path, _safeFolderName(project.projectName)));
+  }
+
+  Future<List<ProjectSummary>> recentProjects({int limit = 20}) async {
+    final root = await _ensureRoot();
+    if (!await root.exists()) {
+      return <ProjectSummary>[];
+    }
+    final children = await root
+        .list()
+        .where((entity) => entity is Directory)
+        .cast<Directory>()
+        .toList();
+    final summaries = <ProjectSummary>[];
+    for (final dir in children) {
+      final file = File(p.join(dir.path, _projectFileName));
+      if (!await file.exists()) {
+        continue;
+      }
+      try {
+        final raw = await file.readAsString();
+        final json = jsonDecode(raw) as Map<String, dynamic>;
+        final project = ProjectRecord.fromJson(json);
+        summaries.add(ProjectSummary(
+          projectId: project.projectId,
+          projectName: project.projectName,
+          lastOpened: project.updatedAt,
+          path: dir.path,
+        ));
+      } catch (_) {
+        continue;
+      }
+    }
+    summaries.sort((a, b) => b.lastOpened.compareTo(a.lastOpened));
+    if (summaries.length > limit) {
+      return summaries.sublist(0, limit);
+    }
+    return summaries;
+  }
+
+  Future<File> ensureExportFile(
+    ProjectRecord project,
+    String fileStem,
+    String extension,
+  ) async {
+    final root = await _ensureRoot();
+    final dir = Directory(
+      p.join(root.path, _safeFolderName(project.projectName), _exportsFolderName),
+    );
+    if (!await dir.exists()) {
+      await dir.create(recursive: true);
+    }
+    final timestamp = DateFormat('yyyyMMdd-HHmm').format(DateTime.now());
+    final fileName = '${fileStem}_$timestamp.$extension';
+    return File(p.join(dir.path, fileName));
+  }
+
+  Future<Directory> ensureSiteDirectory(
+      ProjectRecord project, String siteId) async {
+    final root = await _ensureRoot();
+    final dir = Directory(p.join(root.path, _safeFolderName(project.projectName),
+        _sitesFolderName, siteId));
+    if (!await dir.exists()) {
+      await dir.create(recursive: true);
+    }
+    return dir;
+  }
+
+  Future<ProjectRecord?> loadProjectFromPath(String path) async {
+    return loadProject(Directory(path));
+  }
+
+  Future<File> createBackup(File existing) async {
+    final backup = File('${existing.path}.bak.json');
+    if (await existing.exists()) {
+      await existing.copy(backup.path);
+    }
+    return backup;
+  }
+
+  String _safeFolderName(String name) {
+    final trimmed = name.trim();
+    final sanitized = trimmed.replaceAll(RegExp(r'[^A-Za-z0-9-_]'), '_');
+    return sanitized.isEmpty ? 'Project_${DateTime.now().millisecondsSinceEpoch}' : sanitized;
+  }
+}
+
+class ProjectAutosaveController {
+  ProjectAutosaveController({
+    required this.onPersist,
+    this.interval = const Duration(seconds: 10),
+  });
+
+  final Duration interval;
+  final Future<void> Function(ProjectRecord project) onPersist;
+
+  Timer? _timer;
+  ProjectRecord? _pending;
+
+  void schedule(ProjectRecord project) {
+    _pending = project;
+    _timer?.cancel();
+    _timer = Timer(interval, () async {
+      final pending = _pending;
+      if (pending != null) {
+        await onPersist(pending);
+      }
+    });
+  }
+
+  Future<void> flush() async {
+    _timer?.cancel();
+    final pending = _pending;
+    if (pending != null) {
+      await onPersist(pending);
+    }
+    _pending = null;
+  }
+
+  void dispose() {
+    _timer?.cancel();
+    _pending = null;
+  }
+}

--- a/lib/services/templates_service.dart
+++ b/lib/services/templates_service.dart
@@ -1,0 +1,81 @@
+import 'dart:convert';
+
+import 'package:flutter/services.dart' show rootBundle;
+
+import '../models/site.dart';
+
+class GhostTemplatePoint {
+  GhostTemplatePoint({
+    required this.spacingFeet,
+    required this.apparentResistivityOhmM,
+  });
+
+  factory GhostTemplatePoint.fromJson(Map<String, dynamic> json) {
+    return GhostTemplatePoint(
+      spacingFeet: (json['spacing_ft'] as num).toDouble(),
+      apparentResistivityOhmM: (json['rho_ohm_m'] as num).toDouble(),
+    );
+  }
+
+  final double spacingFeet;
+  final double apparentResistivityOhmM;
+}
+
+class GhostTemplate {
+  GhostTemplate({
+    required this.id,
+    required this.name,
+    this.soil,
+    this.moisture,
+    required List<GhostTemplatePoint> points,
+  }) : points = List.unmodifiable(points);
+
+  factory GhostTemplate.fromJson(Map<String, dynamic> json) {
+    return GhostTemplate(
+      id: json['id'] as String,
+      name: json['name'] as String,
+      soil: (json['soil'] as String?) == null
+          ? null
+          : SoilType.values.byName(json['soil'] as String),
+      moisture: (json['moisture'] as String?) == null
+          ? null
+          : MoistureLevel.values.byName(json['moisture'] as String),
+      points: (json['points'] as List<dynamic>)
+          .map((dynamic e) =>
+              GhostTemplatePoint.fromJson(e as Map<String, dynamic>))
+          .toList(),
+    );
+  }
+
+  final String id;
+  final String name;
+  final SoilType? soil;
+  final MoistureLevel? moisture;
+  final List<GhostTemplatePoint> points;
+
+  bool matches({SoilType? soil, MoistureLevel? moisture}) {
+    final soilMatches = this.soil == null || soil == null || this.soil == soil;
+    final moistureMatches =
+        this.moisture == null || moisture == null || this.moisture == moisture;
+    return soilMatches && moistureMatches;
+  }
+}
+
+class TemplatesService {
+  TemplatesService({this.assetPath = 'assets/templates/ghost_curves.json'});
+
+  final String assetPath;
+  List<GhostTemplate>? _cache;
+
+  Future<List<GhostTemplate>> loadTemplates() async {
+    if (_cache != null) {
+      return _cache!;
+    }
+    final raw = await rootBundle.loadString(assetPath);
+    final decoded = jsonDecode(raw) as List<dynamic>;
+    _cache = decoded
+        .map((dynamic item) => GhostTemplate.fromJson(item as Map<String, dynamic>))
+        .toList();
+    return _cache!;
+  }
+}

--- a/lib/ui/project_workflow/depth_profile_tab.dart
+++ b/lib/ui/project_workflow/depth_profile_tab.dart
@@ -1,0 +1,128 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+
+import '../../models/calc.dart';
+import '../../models/site.dart';
+
+class DepthProfileTab extends StatelessWidget {
+  const DepthProfileTab({super.key, required this.site});
+
+  final SiteRecord site;
+
+  @override
+  Widget build(BuildContext context) {
+    final steps = _depthSteps();
+    if (steps.isEmpty) {
+      return Card(
+        margin: const EdgeInsets.all(12),
+        child: Center(
+          child: Text(
+            'Depth cue will appear once valid resistivity values are recorded.',
+            style: Theme.of(context).textTheme.bodyMedium,
+          ),
+        ),
+      );
+    }
+    return Card(
+      margin: const EdgeInsets.all(12),
+      child: Padding(
+        padding: const EdgeInsets.all(12.0),
+        child: CustomPaint(
+          painter: _DepthProfilePainter(steps: steps),
+          child: Container(),
+        ),
+      ),
+    );
+  }
+
+  List<_DepthStep> _depthSteps() {
+    final steps = <_DepthStep>[];
+    for (final spacing in site.spacings) {
+      final aSample = spacing.orientationA.latest;
+      final bSample = spacing.orientationB.latest;
+      final resistances = [
+        if (aSample != null && !aSample.isBad) aSample.resistanceOhm,
+        if (bSample != null && !bSample.isBad) bSample.resistanceOhm,
+      ].whereType<double>();
+      if (resistances.isEmpty) {
+        continue;
+      }
+      final avgResistance =
+          resistances.reduce((a, b) => a + b) / resistances.length;
+      final rho = rhoAWenner(spacing.spacingFeet, avgResistance);
+      final depthFt = 0.5 * spacing.spacingFeet;
+      steps.add(_DepthStep(depthMeters: feetToMeters(depthFt), rho: rho));
+    }
+    steps.sort((a, b) => a.depthMeters.compareTo(b.depthMeters));
+    return steps;
+  }
+}
+
+class _DepthStep {
+  _DepthStep({required this.depthMeters, required this.rho});
+
+  final double depthMeters;
+  final double rho;
+}
+
+class _DepthProfilePainter extends CustomPainter {
+  _DepthProfilePainter({required this.steps});
+
+  final List<_DepthStep> steps;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final paint = Paint()
+      ..color = Colors.blueAccent
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = 2;
+    final textPainter = TextPainter(
+      textAlign: TextAlign.left,
+      textDirection: TextDirection.ltr,
+    );
+    final maxDepth = steps.last.depthMeters;
+    final maxRho = steps.map((step) => step.rho).reduce((a, b) => a > b ? a : b);
+    final minRho = steps.map((step) => step.rho).reduce((a, b) => a < b ? a : b);
+
+    double depthToY(double depthMeters) {
+      if (maxDepth == 0) {
+        return 0;
+      }
+      return depthMeters / maxDepth * size.height;
+    }
+
+    double rhoToX(double rho) {
+      if (maxRho == minRho) {
+        return size.width * 0.5;
+      }
+      return ((rho - minRho) / (maxRho - minRho)) * (size.width * 0.8) + size.width * 0.1;
+    }
+
+    Offset? previous;
+    for (final step in steps) {
+      final y = depthToY(step.depthMeters);
+      final x = rhoToX(step.rho);
+      final current = Offset(x, y);
+      if (previous != null) {
+        canvas.drawLine(previous!, Offset(previous!.dx, current.dy), paint);
+        canvas.drawLine(Offset(previous!.dx, current.dy), current, paint);
+      }
+      previous = current;
+      textPainter.text = TextSpan(
+        text:
+            '${step.depthMeters.toStringAsFixed(1)} m / ${step.rho.toStringAsFixed(0)} Ω·m',
+        style: const TextStyle(fontSize: 10, color: Colors.black87),
+      );
+      textPainter.layout();
+      textPainter.paint(
+        canvas,
+        Offset(current.dx + 4, current.dy - textPainter.height / 2),
+      );
+    }
+  }
+
+  @override
+  bool shouldRepaint(covariant _DepthProfilePainter oldDelegate) {
+    return !listEquals(oldDelegate.steps, steps);
+  }
+}

--- a/lib/ui/project_workflow/home_page.dart
+++ b/lib/ui/project_workflow/home_page.dart
@@ -1,0 +1,199 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+
+import '../../models/project.dart';
+import '../../services/storage_service.dart';
+import 'project_shell.dart';
+
+class ProjectWorkflowHomePage extends StatefulWidget {
+  const ProjectWorkflowHomePage({super.key});
+
+  @override
+  State<ProjectWorkflowHomePage> createState() => _ProjectWorkflowHomePageState();
+}
+
+class _ProjectWorkflowHomePageState extends State<ProjectWorkflowHomePage> {
+  final ProjectStorageService _storage = ProjectStorageService();
+  late Future<List<ProjectSummary>> _recentFuture;
+
+  @override
+  void initState() {
+    super.initState();
+    _recentFuture = _storage.recentProjects();
+  }
+
+  Future<void> _refresh() async {
+    setState(() {
+      _recentFuture = _storage.recentProjects();
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('ResiCheck Projects'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.refresh),
+            tooltip: 'Refresh projects list',
+            onPressed: _refresh,
+          ),
+        ],
+      ),
+      floatingActionButton: FloatingActionButton.extended(
+        onPressed: _showCreateDialog,
+        icon: const Icon(Icons.add),
+        label: const Text('New Project'),
+      ),
+      body: FutureBuilder<List<ProjectSummary>>(
+        future: _recentFuture,
+        builder: (context, snapshot) {
+          if (snapshot.connectionState == ConnectionState.waiting) {
+            return const Center(child: CircularProgressIndicator());
+          }
+          if (snapshot.hasError) {
+            return Center(
+              child: Text('Failed to load projects: ${snapshot.error}'),
+            );
+          }
+          final projects = snapshot.data ?? const [];
+          if (projects.isEmpty) {
+            return Center(
+              child: Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 24.0),
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    const Icon(Icons.folder_open, size: 64),
+                    const SizedBox(height: 16),
+                    Text(
+                      'No projects found. Create a new project to start logging field data.',
+                      textAlign: TextAlign.center,
+                      style: Theme.of(context).textTheme.titleMedium,
+                    ),
+                    const SizedBox(height: 16),
+                    FilledButton.icon(
+                      icon: const Icon(Icons.add),
+                      label: const Text('Create project'),
+                      onPressed: _showCreateDialog,
+                    ),
+                  ],
+                ),
+              ),
+            );
+          }
+          return ListView.separated(
+            itemCount: projects.length,
+            separatorBuilder: (_, __) => const Divider(height: 1),
+            itemBuilder: (context, index) {
+              final summary = projects[index];
+              return ListTile(
+                leading: const Icon(Icons.workspaces_outline),
+                title: Text(summary.projectName),
+                subtitle: Text('Last opened: ${summary.lastOpened.toLocal()}'),
+                onTap: () => _openProject(summary),
+              );
+            },
+          );
+        },
+      ),
+    );
+  }
+
+  Future<void> _openProject(ProjectSummary summary) async {
+    final record = await _storage.loadProjectFromPath(summary.path);
+    if (!mounted) return;
+    if (record == null) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Failed to open project ${summary.projectName}')),
+      );
+      return;
+    }
+    final directory = Directory(summary.path);
+    await Navigator.of(context).push(MaterialPageRoute(
+      builder: (_) => ProjectShell(
+        initialProject: record,
+        storageService: _storage,
+        projectDirectory: directory,
+      ),
+    ));
+    await _refresh();
+  }
+
+  Future<void> _showCreateDialog() async {
+    final controller = TextEditingController();
+    final spacingsController = TextEditingController(text: '2.5,5,10,20,40,60');
+    final result = await showDialog<_NewProjectResult>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('New Project'),
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            TextField(
+              controller: controller,
+              autofocus: true,
+              decoration: const InputDecoration(labelText: 'Project name'),
+            ),
+            const SizedBox(height: 12),
+            TextField(
+              controller: spacingsController,
+              decoration: const InputDecoration(
+                labelText: 'a-spacings (ft)',
+                helperText: 'Comma separated, per project defaults',
+              ),
+            ),
+          ],
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(),
+            child: const Text('Cancel'),
+          ),
+          FilledButton(
+            onPressed: () {
+              final name = controller.text.trim();
+              if (name.isEmpty) {
+                return;
+              }
+              final spacings = spacingsController.text
+                  .split(',')
+                  .map((value) => double.tryParse(value.trim()))
+                  .whereType<double>()
+                  .toList();
+              Navigator.of(context)
+                  .pop(_NewProjectResult(name: name, spacings: spacings));
+            },
+            child: const Text('Create'),
+          ),
+        ],
+      ),
+    );
+    if (result == null) {
+      return;
+    }
+    final project = await _storage.createProject(
+      result.name,
+      canonicalSpacingsFeet: result.spacings.isEmpty ? null : result.spacings,
+    );
+    final directory = await _storage.projectDirectory(project);
+    if (!mounted) return;
+    await Navigator.of(context).push(MaterialPageRoute(
+      builder: (_) => ProjectShell(
+        initialProject: project,
+        storageService: _storage,
+        projectDirectory: directory,
+      ),
+    ));
+    await _refresh();
+  }
+}
+
+class _NewProjectResult {
+  _NewProjectResult({required this.name, required this.spacings});
+
+  final String name;
+  final List<double> spacings;
+}

--- a/lib/ui/project_workflow/plots_panel.dart
+++ b/lib/ui/project_workflow/plots_panel.dart
@@ -1,0 +1,296 @@
+import 'dart:math' as math;
+
+import 'package:collection/collection.dart';
+import 'package:fl_chart/fl_chart.dart';
+import 'package:flutter/material.dart';
+
+import '../../models/calc.dart';
+import '../../models/direction_reading.dart';
+import '../../models/project.dart';
+import '../../models/site.dart';
+import '../../services/templates_service.dart';
+
+class GhostSeriesPoint {
+  const GhostSeriesPoint({required this.spacingFt, required this.rho});
+
+  final double spacingFt;
+  final double rho;
+}
+
+class PlotsPanel extends StatelessWidget {
+  const PlotsPanel({
+    super.key,
+    required this.project,
+    required this.selectedSite,
+    required this.showOutliers,
+    required this.lockAxes,
+    required this.showAllSites,
+    this.template,
+    this.averageGhost = const [],
+  });
+
+  final ProjectRecord project;
+  final SiteRecord selectedSite;
+  final bool showOutliers;
+  final bool lockAxes;
+  final bool showAllSites;
+  final GhostTemplate? template;
+  final List<GhostSeriesPoint> averageGhost;
+
+  @override
+  Widget build(BuildContext context) {
+    if (showAllSites) {
+      return _buildAllSitesComposite(context);
+    }
+    return _buildPrimaryChart(context, selectedSite);
+  }
+
+  Widget _buildAllSitesComposite(BuildContext context) {
+    return ListView(
+      padding: const EdgeInsets.all(12),
+      children: [
+        Wrap(
+          spacing: 12,
+          runSpacing: 12,
+          children: [
+            for (final site in project.sites)
+              SizedBox(
+                width: 320,
+                height: 220,
+                child: Card(
+                  child: Padding(
+                    padding: const EdgeInsets.all(12.0),
+                    child: _buildChartForSite(context, site, compact: true),
+                  ),
+                ),
+              ),
+          ],
+        ),
+      ],
+    );
+  }
+
+  Widget _buildPrimaryChart(BuildContext context, SiteRecord site) {
+    return Padding(
+      padding: const EdgeInsets.all(12.0),
+      child: _buildChartForSite(context, site, compact: false),
+    );
+  }
+
+  Widget _buildChartForSite(BuildContext context, SiteRecord site,
+      {required bool compact}) {
+    final data = buildSeriesForSite(site, showOutliers: showOutliers);
+    if (data.aSeries.isEmpty && data.bSeries.isEmpty) {
+      return Center(
+        child: Text(
+          'No readings yet for ${site.displayName}.',
+          style: Theme.of(context).textTheme.bodyMedium,
+        ),
+      );
+    }
+    final axis = _computeAxisRanges(site);
+    final ghostSpots = averageGhost
+        .sortedBy((point) => point.spacingFt)
+        .map((point) => FlSpot(_log(point.spacingFt), _log(point.rho)))
+        .toList();
+    final templateSpots = template == null
+        ? <FlSpot>[]
+        : template!.points
+            .sortedBy((point) => point.spacingFeet)
+            .map((point) => FlSpot(
+                  _log(point.spacingFeet),
+                  _log(point.apparentResistivityOhmM),
+                ))
+            .toList();
+    return LineChart(
+      LineChartData(
+        lineTouchData: LineTouchData(
+          touchTooltipData: LineTouchTooltipData(
+            tooltipBgColor: Theme.of(context).colorScheme.surface.withOpacity(0.9),
+            getTooltipItems: (touchedSpots) {
+              return touchedSpots.map((spot) {
+                final spacing = math.pow(10, spot.x);
+                final rho = math.pow(10, spot.y);
+                return LineTooltipItem(
+                  'a=${spacing.toStringAsFixed(1)} ft\nρa=${rho.toStringAsFixed(1)} Ω·m',
+                  Theme.of(context).textTheme.bodyMedium!,
+                );
+              }).toList();
+            },
+          ),
+        ),
+        minX: axis.minX,
+        maxX: axis.maxX,
+        minY: axis.minY,
+        maxY: axis.maxY,
+        titlesData: FlTitlesData(
+          bottomTitles: AxisTitles(
+            sideTitles: SideTitles(
+              showTitles: true,
+              interval: (axis.maxX - axis.minX) / 4,
+              getTitlesWidget: (value, meta) {
+                final spacing = math.pow(10, value);
+                return Text('${spacing.toStringAsFixed(1)} ft');
+              },
+            ),
+            axisNameWidget: const Padding(
+              padding: EdgeInsets.only(top: 8.0),
+              child: Text('Spacing a (ft)'),
+            ),
+          ),
+          leftTitles: AxisTitles(
+            sideTitles: SideTitles(
+              showTitles: true,
+              reservedSize: 60,
+              interval: (axis.maxY - axis.minY) / 4,
+              getTitlesWidget: (value, meta) {
+                final rho = math.pow(10, value);
+                return Text('${rho.toStringAsFixed(0)}');
+              },
+            ),
+            axisNameWidget: const Padding(
+              padding: EdgeInsets.only(right: 8.0),
+              child: Text('ρa (Ω·m)'),
+            ),
+          ),
+          rightTitles: const AxisTitles(sideTitles: SideTitles(showTitles: false)),
+          topTitles: const AxisTitles(sideTitles: SideTitles(showTitles: false)),
+        ),
+        gridData: FlGridData(show: true, drawVerticalLine: true, drawHorizontalLine: true),
+        borderData: FlBorderData(show: true),
+        lineBarsData: [
+          if (data.aSeries.isNotEmpty)
+            LineChartBarData(
+              spots: data.aSeries,
+              barWidth: 3,
+              color: Theme.of(context).colorScheme.primary,
+              isCurved: false,
+              dotData: const FlDotData(show: true),
+            ),
+          if (data.bSeries.isNotEmpty)
+            LineChartBarData(
+              spots: data.bSeries,
+              barWidth: 3,
+              color: Theme.of(context).colorScheme.secondary,
+              isCurved: false,
+              dotData: const FlDotData(show: true),
+            ),
+          if (ghostSpots.isNotEmpty)
+            LineChartBarData(
+              spots: ghostSpots,
+              barWidth: 2,
+              color: Theme.of(context).colorScheme.tertiary,
+              dashArray: [6, 6],
+              dotData: const FlDotData(show: false),
+            ),
+          if (templateSpots.isNotEmpty)
+            LineChartBarData(
+              spots: templateSpots,
+              barWidth: 2,
+              color: Theme.of(context).colorScheme.outline,
+              dashArray: [4, 4],
+              dotData: const FlDotData(show: false),
+            ),
+        ],
+      ),
+      duration: compact ? Duration.zero : const Duration(milliseconds: 300),
+    );
+  }
+
+  _AxisRanges _computeAxisRanges(SiteRecord site) {
+    final spacings = lockAxes
+        ? project.sites.expand((s) => s.spacings.map((p) => p.spacingFeet))
+        : site.spacings.map((p) => p.spacingFeet);
+    final rhoValues = lockAxes
+        ? project.sites.expand((s) => _collectRho(s))
+        : _collectRho(site);
+    final minSpacing = spacings.isEmpty ? 1.0 : spacings.reduce(math.min);
+    final maxSpacing = spacings.isEmpty ? 10.0 : spacings.reduce(math.max);
+    final minRho = rhoValues.isEmpty ? 10.0 : rhoValues.reduce(math.min);
+    final maxRho = rhoValues.isEmpty ? 1000.0 : rhoValues.reduce(math.max);
+    return _AxisRanges(
+      minX: _log(minSpacing) - 0.1,
+      maxX: _log(maxSpacing) + 0.1,
+      minY: _log(minRho) - 0.2,
+      maxY: _log(maxRho) + 0.2,
+    );
+  }
+
+  Iterable<double> _collectRho(SiteRecord site) sync* {
+    final qcConfig = const QcConfig();
+    for (final spacing in site.spacings) {
+      for (final orientation in [spacing.orientationA, spacing.orientationB]) {
+        final latest = orientation.latest;
+        if (latest == null || latest.resistanceOhm == null) {
+          continue;
+        }
+        final outlier = latest.isBad ||
+            (!showOutliers &&
+                latest.resistanceOhm!.abs() > qcConfig.outlierCapOhm);
+        if (outlier) {
+          continue;
+        }
+        yield rhoAWenner(spacing.spacingFeet, latest.resistanceOhm!);
+      }
+    }
+  }
+
+  double _log(double value) => math.log(value) / math.ln10;
+}
+
+class SeriesData {
+  SeriesData({required this.aSeries, required this.bSeries});
+
+  final List<FlSpot> aSeries;
+  final List<FlSpot> bSeries;
+}
+
+SeriesData buildSeriesForSite(SiteRecord site, {required bool showOutliers}) {
+  final qcConfig = const QcConfig();
+  final aSpots = <FlSpot>[];
+  final bSpots = <FlSpot>[];
+  for (final spacing in site.spacings) {
+    final aSample = spacing.orientationA.latest;
+    final bSample = spacing.orientationB.latest;
+    if (aSample != null && aSample.resistanceOhm != null) {
+      final outlier = aSample.isBad ||
+          (!showOutliers &&
+              (aSample.resistanceOhm!.abs() > qcConfig.outlierCapOhm));
+      if (!outlier) {
+        aSpots.add(
+          FlSpot(
+            math.log(spacing.spacingFeet) / math.ln10,
+            math.log(rhoAWenner(spacing.spacingFeet, aSample.resistanceOhm!)) /
+                math.ln10,
+          ),
+        );
+      }
+    }
+    if (bSample != null && bSample.resistanceOhm != null) {
+      final outlier = bSample.isBad ||
+          (!showOutliers &&
+              (bSample.resistanceOhm!.abs() > qcConfig.outlierCapOhm));
+      if (!outlier) {
+        bSpots.add(
+          FlSpot(
+            math.log(spacing.spacingFeet) / math.ln10,
+            math.log(rhoAWenner(spacing.spacingFeet, bSample.resistanceOhm!)) /
+                math.ln10,
+          ),
+        );
+      }
+    }
+  }
+  aSpots.sort((a, b) => a.x.compareTo(b.x));
+  bSpots.sort((a, b) => a.x.compareTo(b.x));
+  return SeriesData(aSeries: aSpots, bSeries: bSpots);
+}
+
+class _AxisRanges {
+  _AxisRanges({required this.minX, required this.maxX, required this.minY, required this.maxY});
+
+  final double minX;
+  final double maxX;
+  final double minY;
+  final double maxY;
+}

--- a/lib/ui/project_workflow/project_shell.dart
+++ b/lib/ui/project_workflow/project_shell.dart
@@ -1,0 +1,660 @@
+import 'dart:io';
+
+import 'package:collection/collection.dart';
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+
+import '../../models/calc.dart';
+import '../../models/direction_reading.dart';
+import '../../models/project.dart';
+import '../../models/site.dart';
+import '../../services/export_service.dart';
+import '../../services/storage_service.dart';
+import '../../services/templates_service.dart';
+import 'depth_profile_tab.dart';
+import 'plots_panel.dart';
+import 'shortcuts.dart';
+import 'table_panel.dart';
+
+class ProjectShell extends StatefulWidget {
+  const ProjectShell({
+    super.key,
+    required this.initialProject,
+    required this.storageService,
+    required this.projectDirectory,
+  });
+
+  final ProjectRecord initialProject;
+  final ProjectStorageService storageService;
+  final Directory projectDirectory;
+
+  @override
+  State<ProjectShell> createState() => _ProjectShellState();
+}
+
+class _ProjectShellState extends State<ProjectShell> {
+  late ProjectRecord _project;
+  SiteRecord? _selectedSite;
+  bool _showOutliers = false;
+  bool _lockAxes = false;
+  bool _showAllSites = false;
+  GhostTemplate? _selectedTemplate;
+  final TemplatesService _templatesService = TemplatesService();
+  List<GhostTemplate> _templates = const [];
+  late ProjectAutosaveController _autosave;
+  late ExportService _exportService;
+  String _saveIndicator = 'Saved';
+  final List<ProjectRecord> _history = [];
+  int _historyIndex = -1;
+  double? _focusedSpacing;
+  OrientationKind? _focusedOrientation;
+
+  @override
+  void initState() {
+    super.initState();
+    _project = widget.initialProject;
+    _selectedSite = _project.sites.firstOrNull;
+    _exportService = ExportService(widget.storageService);
+    _autosave = ProjectAutosaveController(onPersist: _persistProject);
+    _history.add(_project);
+    _historyIndex = 0;
+    _loadTemplates();
+  }
+
+  @override
+  void dispose() {
+    _autosave.dispose();
+    super.dispose();
+  }
+
+  Future<void> _loadTemplates() async {
+    try {
+      final templates = await _templatesService.loadTemplates();
+      if (!mounted) return;
+      setState(() {
+        _templates = templates;
+      });
+    } catch (error) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Failed to load template curves: $error')),
+      );
+    }
+  }
+
+  Future<void> _persistProject(ProjectRecord project) async {
+    final saved = await widget.storageService.saveProject(
+      project,
+      directoryOverride: widget.projectDirectory,
+    );
+    if (!mounted) {
+      return;
+    }
+    setState(() {
+      _project = saved;
+      _selectedSite = saved.siteById(_selectedSite?.siteId ?? '') ?? saved.sites.firstOrNull;
+      _saveIndicator = 'Saved ${DateFormat('HH:mm:ss').format(DateTime.now())}';
+    });
+  }
+
+  void _scheduleAutosave() {
+    setState(() {
+      _saveIndicator = 'Saving…';
+    });
+    _autosave.schedule(_project);
+  }
+
+  void _selectSite(SiteRecord site) {
+    setState(() {
+      _selectedSite = site;
+    });
+  }
+
+  void _recordFocus(double spacingFt, OrientationKind orientation) {
+    _focusedSpacing = spacingFt;
+    _focusedOrientation = orientation;
+  }
+
+  void _pushHistory(ProjectRecord project) {
+    if (_historyIndex < _history.length - 1) {
+      _history.removeRange(_historyIndex + 1, _history.length);
+    }
+    _history.add(project);
+    _historyIndex = _history.length - 1;
+  }
+
+  void _applyProjectUpdate(ProjectRecord Function(ProjectRecord current) updater) {
+    final updated = updater(_project);
+    setState(() {
+      _project = updated;
+      _selectedSite = updated.siteById(_selectedSite?.siteId ?? '') ?? updated.sites.firstOrNull;
+      _pushHistory(updated);
+    });
+    _scheduleAutosave();
+  }
+
+  void _handleReadingSubmitted(
+    double spacingFt,
+    OrientationKind orientation,
+    double? resistance,
+    double? sd,
+  ) {
+    final site = _selectedSite;
+    if (site == null) {
+      return;
+    }
+    if (resistance == null && sd == null) {
+      return;
+    }
+    _applyProjectUpdate((project) {
+      return project.updateSite(site.siteId, (current) {
+        return current.updateSpacing(spacingFt, (record) {
+          final history = record.historyFor(orientation);
+          final latest = history.latest;
+          final sample = DirectionReadingSample(
+            timestamp: DateTime.now(),
+            resistanceOhm: resistance ?? latest?.resistanceOhm,
+            standardDeviationPercent: sd ?? latest?.standardDeviationPercent,
+            note: latest?.note ?? '',
+            isBad: false,
+          );
+          final updatedHistory = history.addSample(sample);
+          return record.updateHistory(orientation, updatedHistory);
+        });
+      });
+    });
+  }
+
+  void _handleBadToggle(
+    double spacingFt,
+    OrientationKind orientation,
+    bool isBad,
+  ) {
+    final site = _selectedSite;
+    if (site == null) {
+      return;
+    }
+    _applyProjectUpdate((project) {
+      return project.updateSite(site.siteId, (current) {
+        return current.updateSpacing(spacingFt, (record) {
+          final history = record.historyFor(orientation);
+          final updatedHistory = history.updateLatest(
+            (sample) => sample.copyWith(isBad: isBad),
+          );
+          return record.updateHistory(orientation, updatedHistory);
+        });
+      });
+    });
+  }
+
+  void _handleNoteChanged(
+    double spacingFt,
+    OrientationKind orientation,
+    String note,
+  ) {
+    final site = _selectedSite;
+    if (site == null) {
+      return;
+    }
+    _applyProjectUpdate((project) {
+      return project.updateSite(site.siteId, (current) {
+        return current.updateSpacing(spacingFt, (record) {
+          final history = record.historyFor(orientation);
+          final updatedHistory = history.updateLatest(
+            (sample) => sample.copyWith(note: note),
+          );
+          return record.updateHistory(orientation, updatedHistory);
+        });
+      });
+    });
+  }
+
+  void _handleSdChanged(
+    double spacingFt,
+    OrientationKind orientation,
+    double? sd,
+  ) {
+    _handleReadingSubmitted(spacingFt, orientation, null, sd);
+  }
+
+  void _handleMetadataChanged({
+    double? power,
+    int? stacks,
+    SoilType? soil,
+    MoistureLevel? moisture,
+  }) {
+    final site = _selectedSite;
+    if (site == null) {
+      return;
+    }
+    _applyProjectUpdate((project) {
+      return project.updateSite(site.siteId, (current) {
+        return current.updateMetadata(
+          powerMilliAmps: power,
+          stacks: stacks,
+          soil: soil,
+          moisture: moisture,
+        );
+      });
+    });
+  }
+
+  Future<void> _showHistory(
+    double spacingFt,
+    OrientationKind orientation,
+  ) async {
+    final site = _selectedSite;
+    if (site == null) {
+      return;
+    }
+    final record = site.spacing(spacingFt);
+    final history = record?.historyFor(orientation);
+    if (history == null) {
+      return;
+    }
+    await showModalBottomSheet<void>(
+      context: context,
+      builder: (context) {
+        return ListView(
+          padding: const EdgeInsets.all(16),
+          children: [
+            Text(
+              'History for ${history.label} @ ${spacingFt.toStringAsFixed(1)} ft',
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+            const SizedBox(height: 12),
+            for (final sample in history.samples.reversed)
+              ListTile(
+                leading: Icon(
+                  sample.isBad ? Icons.flag : Icons.check_circle,
+                  color: sample.isBad
+                      ? Theme.of(context).colorScheme.error
+                      : Theme.of(context).colorScheme.primary,
+                ),
+                title: Text(
+                    'R=${sample.resistanceOhm?.toStringAsFixed(2) ?? '—'} Ω, SD=${sample.standardDeviationPercent?.toStringAsFixed(1) ?? '—'}%'),
+                subtitle: Text(
+                  '${DateFormat('y-MM-dd HH:mm:ss').format(sample.timestamp)}\n${sample.note}',
+                ),
+              ),
+          ],
+        );
+      },
+    );
+  }
+
+  Future<void> _addSite() async {
+    final controller = TextEditingController();
+    String orientationA = 'N–S';
+    String orientationB = 'W–E';
+    final result = await showDialog<_NewSiteConfig>(
+      context: context,
+      builder: (context) {
+        return AlertDialog(
+          title: const Text('New Site'),
+          content: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              TextField(
+                controller: controller,
+                decoration: const InputDecoration(labelText: 'Site ID'),
+              ),
+              const SizedBox(height: 12),
+              DropdownButtonFormField<String>(
+                value: orientationA,
+                decoration: const InputDecoration(labelText: 'Orientation A'),
+                items: const [
+                  DropdownMenuItem(value: 'N–S', child: Text('N–S')),
+                  DropdownMenuItem(value: 'W–E', child: Text('W–E')),
+                  DropdownMenuItem(value: 'NW–SE', child: Text('NW–SE')),
+                  DropdownMenuItem(value: 'SW–NE', child: Text('SW–NE')),
+                ],
+                onChanged: (value) {
+                  orientationA = value ?? orientationA;
+                },
+              ),
+              const SizedBox(height: 12),
+              DropdownButtonFormField<String>(
+                value: orientationB,
+                decoration: const InputDecoration(labelText: 'Orientation B'),
+                items: const [
+                  DropdownMenuItem(value: 'N–S', child: Text('N–S')),
+                  DropdownMenuItem(value: 'W–E', child: Text('W–E')),
+                  DropdownMenuItem(value: 'NW–SE', child: Text('NW–SE')),
+                  DropdownMenuItem(value: 'SW–NE', child: Text('SW–NE')),
+                ],
+                onChanged: (value) {
+                  orientationB = value ?? orientationB;
+                },
+              ),
+            ],
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(context).pop(),
+              child: const Text('Cancel'),
+            ),
+            FilledButton(
+              onPressed: () {
+                final id = controller.text.trim();
+                if (id.isEmpty) {
+                  return;
+                }
+                Navigator.of(context).pop(_NewSiteConfig(
+                  siteId: id,
+                  orientationA: orientationA,
+                  orientationB: orientationB,
+                ));
+              },
+              child: const Text('Create'),
+            ),
+          ],
+        );
+      },
+    );
+    if (result == null) {
+      return;
+    }
+    final canonicalSpacings = _project.canonicalSpacingsFeet;
+    final site = SiteRecord(
+      siteId: result.siteId,
+      displayName: result.siteId,
+      powerMilliAmps: _project.defaultPowerMilliAmps,
+      stacks: _project.defaultStacks,
+      spacings: canonicalSpacings
+          .map(
+            (spacing) => SpacingRecord.seed(
+              spacingFeet: spacing,
+              orientationALabel: result.orientationA,
+              orientationBLabel: result.orientationB,
+            ),
+          )
+          .toList(),
+    );
+    _applyProjectUpdate((project) => project.upsertSite(site));
+    setState(() {
+      _selectedSite = site;
+    });
+  }
+
+  void _toggleAllSitesView() {
+    setState(() {
+      _showAllSites = !_showAllSites;
+    });
+  }
+
+  void _toggleOutliers() {
+    setState(() {
+      _showOutliers = !_showOutliers;
+    });
+  }
+
+  void _toggleLockAxes() {
+    setState(() {
+      _lockAxes = !_lockAxes;
+    });
+  }
+
+  Future<void> _exportSite() async {
+    final site = _selectedSite;
+    if (site == null) {
+      return;
+    }
+    try {
+      final csvFile = await _exportService.exportFieldCsv(_project, site);
+      final datFile = await _exportService.exportSurferDat(_project, site);
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text('Exported CSV & DAT to ${csvFile.parent.path}'),
+        ),
+      );
+    } catch (error) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Export failed: $error')),
+      );
+    }
+  }
+
+  void _undo() {
+    if (_historyIndex <= 0) {
+      return;
+    }
+    setState(() {
+      _historyIndex--;
+      _project = _history[_historyIndex];
+      _selectedSite =
+          _project.siteById(_selectedSite?.siteId ?? '') ?? _project.sites.firstOrNull;
+    });
+  }
+
+  void _redo() {
+    if (_historyIndex >= _history.length - 1) {
+      return;
+    }
+    setState(() {
+      _historyIndex++;
+      _project = _history[_historyIndex];
+      _selectedSite =
+          _project.siteById(_selectedSite?.siteId ?? '') ?? _project.sites.firstOrNull;
+    });
+  }
+
+  void _markFocusedBad() {
+    final site = _selectedSite;
+    if (site == null || _focusedSpacing == null || _focusedOrientation == null) {
+      return;
+    }
+    final record = site.spacing(_focusedSpacing!);
+    final history = record?.historyFor(_focusedOrientation!);
+    if (history == null || history.samples.isEmpty) {
+      return;
+    }
+    final latest = history.latest;
+    final isBad = !(latest?.isBad ?? false);
+    _handleBadToggle(_focusedSpacing!, _focusedOrientation!, isBad);
+  }
+
+  List<GhostSeriesPoint> _computeSiteAverage(SiteRecord? site) {
+    if (site == null) {
+      return const [];
+    }
+    final points = <GhostSeriesPoint>[];
+    for (final spacing in site.spacings) {
+      final rhoValues = <double>[];
+      final aSample = spacing.orientationA.latest;
+      final bSample = spacing.orientationB.latest;
+      if (aSample != null && !aSample.isBad && aSample.resistanceOhm != null) {
+        rhoValues.add(rhoAWenner(spacing.spacingFeet, aSample.resistanceOhm!));
+      }
+      if (bSample != null && !bSample.isBad && bSample.resistanceOhm != null) {
+        rhoValues.add(rhoAWenner(spacing.spacingFeet, bSample.resistanceOhm!));
+      }
+      if (rhoValues.isEmpty) {
+        continue;
+      }
+      final avg = rhoValues.reduce((a, b) => a + b) / rhoValues.length;
+      points.add(GhostSeriesPoint(spacingFt: spacing.spacingFeet, rho: avg));
+    }
+    points.sort((a, b) => a.spacingFt.compareTo(b.spacingFt));
+    return points;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final site = _selectedSite;
+    final averageGhost = _computeSiteAverage(site);
+    final templateOptions = _templates;
+
+    return ProjectWorkflowShortcuts(
+      onToggleOutliers: _toggleOutliers,
+      onToggleAllSites: _toggleAllSitesView,
+      onToggleLockAxes: _toggleLockAxes,
+      onSave: () {
+        _autosave.flush();
+      },
+      onExport: _exportSite,
+      onNewSite: _addSite,
+      onUndo: _undo,
+      onRedo: _redo,
+      onMarkBad: _markFocusedBad,
+      child: Scaffold(
+        appBar: AppBar(
+          title: Text(_project.projectName),
+          actions: [
+            if (_selectedTemplate != null)
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 8.0),
+                child: Chip(
+                  avatar: const Icon(Icons.timeline),
+                  label: Text(_selectedTemplate!.name),
+                ),
+              ),
+            IconButton(
+              icon: Icon(_showOutliers ? Icons.visibility : Icons.visibility_off),
+              tooltip: _showOutliers ? 'Hide outliers' : 'Show outliers',
+              onPressed: _toggleOutliers,
+            ),
+            IconButton(
+              icon: const Icon(Icons.save_alt),
+              tooltip: 'Export CSV & DAT',
+              onPressed: _exportSite,
+            ),
+            IconButton(
+              icon: const Icon(Icons.add_location_alt),
+              tooltip: 'New site',
+              onPressed: _addSite,
+            ),
+            const SizedBox(width: 8),
+          ],
+        ),
+        body: site == null
+            ? Center(
+                child: Text(
+                  'No sites yet. Add a site to begin collecting readings.',
+                  style: Theme.of(context).textTheme.titleMedium,
+                ),
+              )
+            : Column(
+                children: [
+                  Container(
+                    width: double.infinity,
+                    color: Theme.of(context).colorScheme.surfaceContainerHigh,
+                    padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+                    child: Row(
+                      children: [
+                        Text(_saveIndicator),
+                        const SizedBox(width: 16),
+                        DropdownButton<GhostTemplate?>(
+                          value: _selectedTemplate,
+                          hint: const Text('Template ghost curve'),
+                          items: [
+                            const DropdownMenuItem<GhostTemplate?>(
+                              value: null,
+                              child: Text('No template'),
+                            ),
+                            for (final template in templateOptions)
+                              DropdownMenuItem<GhostTemplate?>(
+                                value: template,
+                                child: Text(template.name),
+                              ),
+                          ],
+                          onChanged: (value) {
+                            setState(() {
+                              _selectedTemplate = value;
+                            });
+                          },
+                        ),
+                        const Spacer(),
+                        Text('Outliers ${_showOutliers ? 'shown' : 'hidden'}'),
+                        const SizedBox(width: 12),
+                        Text('Axes ${_lockAxes ? 'locked' : 'auto'}'),
+                      ],
+                    ),
+                  ),
+                  Expanded(
+                    child: Row(
+                      children: [
+                        Container(
+                          width: 220,
+                          decoration: BoxDecoration(
+                            border: Border(
+                              right: BorderSide(
+                                color: Theme.of(context).colorScheme.outlineVariant,
+                              ),
+                            ),
+                          ),
+                          child: _buildSiteList(),
+                        ),
+                        Expanded(
+                          child: Row(
+                            children: [
+                              Expanded(
+                                child: PlotsPanel(
+                                  project: _project,
+                                  selectedSite: site,
+                                  showOutliers: _showOutliers,
+                                  lockAxes: _lockAxes,
+                                  showAllSites: _showAllSites,
+                                  template: _selectedTemplate,
+                                  averageGhost: averageGhost,
+                                ),
+                              ),
+                              SizedBox(
+                                width: 420,
+                                child: TablePanel(
+                                  project: _project,
+                                  site: site,
+                                  onResistanceChanged: _handleReadingSubmitted,
+                                  onSdChanged: _handleSdChanged,
+                                  onNoteChanged: _handleNoteChanged,
+                                  onToggleBad: _handleBadToggle,
+                                  onMetadataChanged: _handleMetadataChanged,
+                                  onShowHistory: _showHistory,
+                                  onFocusChanged: _recordFocus,
+                                ),
+                              ),
+                            ],
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                  SizedBox(
+                    height: 220,
+                    child: DepthProfileTab(site: site),
+                  ),
+                ],
+              ),
+      ),
+    );
+  }
+
+  Widget _buildSiteList() {
+    return ListView(
+      children: [
+        for (final site in _project.sites)
+          ListTile(
+            title: Text(site.displayName),
+            subtitle: Text('${site.spacings.length} spacings'),
+            selected: _selectedSite?.siteId == site.siteId,
+            onTap: () => _selectSite(site),
+          ),
+      ],
+    );
+  }
+}
+
+class _NewSiteConfig {
+  _NewSiteConfig({
+    required this.siteId,
+    required this.orientationA,
+    required this.orientationB,
+  });
+
+  final String siteId;
+  final String orientationA;
+  final String orientationB;
+}
+

--- a/lib/ui/project_workflow/shortcuts.dart
+++ b/lib/ui/project_workflow/shortcuts.dart
@@ -1,0 +1,127 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+class ProjectWorkflowShortcuts extends StatelessWidget {
+  const ProjectWorkflowShortcuts({
+    super.key,
+    required this.child,
+    required this.onToggleOutliers,
+    required this.onToggleAllSites,
+    required this.onToggleLockAxes,
+    required this.onSave,
+    required this.onExport,
+    required this.onNewSite,
+    required this.onUndo,
+    required this.onRedo,
+    required this.onMarkBad,
+  });
+
+  final Widget child;
+  final VoidCallback onToggleOutliers;
+  final VoidCallback onToggleAllSites;
+  final VoidCallback onToggleLockAxes;
+  final VoidCallback onSave;
+  final VoidCallback onExport;
+  final VoidCallback onNewSite;
+  final VoidCallback onUndo;
+  final VoidCallback onRedo;
+  final VoidCallback onMarkBad;
+
+  @override
+  Widget build(BuildContext context) {
+    return Shortcuts(
+      shortcuts: <ShortcutActivator, Intent>{
+        LogicalKeySet(LogicalKeyboardKey.keyX): const _MarkBadIntent(),
+        LogicalKeySet(LogicalKeyboardKey.keyF): const _ToggleAllSitesIntent(),
+        LogicalKeySet(LogicalKeyboardKey.keyO): const _ToggleOutliersIntent(),
+        LogicalKeySet(LogicalKeyboardKey.keyL): const _ToggleLockAxesIntent(),
+        LogicalKeySet(LogicalKeyboardKey.keyN): const _NewSiteIntent(),
+        LogicalKeySet(LogicalKeyboardKey.control, LogicalKeyboardKey.keyS):
+            const _SaveIntent(),
+        LogicalKeySet(LogicalKeyboardKey.control, LogicalKeyboardKey.keyE):
+            const _ExportIntent(),
+        LogicalKeySet(LogicalKeyboardKey.control, LogicalKeyboardKey.keyZ):
+            const _UndoIntent(),
+        LogicalKeySet(LogicalKeyboardKey.control, LogicalKeyboardKey.shift, LogicalKeyboardKey.keyZ):
+            const _RedoIntent(),
+      },
+      child: Actions(
+        actions: <Type, Action<Intent>>{
+          _MarkBadIntent: CallbackAction<_MarkBadIntent>(onInvoke: (_) {
+            onMarkBad();
+            return null;
+          }),
+          _ToggleOutliersIntent: CallbackAction<_ToggleOutliersIntent>(onInvoke: (_) {
+            onToggleOutliers();
+            return null;
+          }),
+          _ToggleAllSitesIntent: CallbackAction<_ToggleAllSitesIntent>(onInvoke: (_) {
+            onToggleAllSites();
+            return null;
+          }),
+          _ToggleLockAxesIntent: CallbackAction<_ToggleLockAxesIntent>(onInvoke: (_) {
+            onToggleLockAxes();
+            return null;
+          }),
+          _SaveIntent: CallbackAction<_SaveIntent>(onInvoke: (_) {
+            onSave();
+            return null;
+          }),
+          _ExportIntent: CallbackAction<_ExportIntent>(onInvoke: (_) {
+            onExport();
+            return null;
+          }),
+          _NewSiteIntent: CallbackAction<_NewSiteIntent>(onInvoke: (_) {
+            onNewSite();
+            return null;
+          }),
+          _UndoIntent: CallbackAction<_UndoIntent>(onInvoke: (_) {
+            onUndo();
+            return null;
+          }),
+          _RedoIntent: CallbackAction<_RedoIntent>(onInvoke: (_) {
+            onRedo();
+            return null;
+          }),
+        },
+        child: Focus(autofocus: true, child: child),
+      ),
+    );
+  }
+}
+
+class _MarkBadIntent extends Intent {
+  const _MarkBadIntent();
+}
+
+class _ToggleOutliersIntent extends Intent {
+  const _ToggleOutliersIntent();
+}
+
+class _ToggleAllSitesIntent extends Intent {
+  const _ToggleAllSitesIntent();
+}
+
+class _ToggleLockAxesIntent extends Intent {
+  const _ToggleLockAxesIntent();
+}
+
+class _SaveIntent extends Intent {
+  const _SaveIntent();
+}
+
+class _ExportIntent extends Intent {
+  const _ExportIntent();
+}
+
+class _NewSiteIntent extends Intent {
+  const _NewSiteIntent();
+}
+
+class _UndoIntent extends Intent {
+  const _UndoIntent();
+}
+
+class _RedoIntent extends Intent {
+  const _RedoIntent();
+}

--- a/lib/ui/project_workflow/table_panel.dart
+++ b/lib/ui/project_workflow/table_panel.dart
@@ -1,0 +1,489 @@
+import 'package:flutter/material.dart';
+
+import '../../models/calc.dart';
+import '../../models/direction_reading.dart';
+import '../../models/site.dart';
+
+class TablePanel extends StatelessWidget {
+  const TablePanel({
+    super.key,
+    required this.site,
+    required this.onResistanceChanged,
+    required this.onSdChanged,
+    required this.onNoteChanged,
+    required this.onToggleBad,
+    required this.onMetadataChanged,
+    required this.onShowHistory,
+    required this.onFocusChanged,
+  });
+
+  final SiteRecord site;
+  final void Function(
+    double spacingFt,
+    OrientationKind orientation,
+    double? resistance,
+    double? sd,
+  ) onResistanceChanged;
+  final void Function(
+    double spacingFt,
+    OrientationKind orientation,
+    double? sd,
+  ) onSdChanged;
+  final void Function(
+    double spacingFt,
+    OrientationKind orientation,
+    String note,
+  ) onNoteChanged;
+  final void Function(
+    double spacingFt,
+    OrientationKind orientation,
+    bool isBad,
+  ) onToggleBad;
+  final void Function({
+    double? power,
+    int? stacks,
+    SoilType? soil,
+    MoistureLevel? moisture,
+  }) onMetadataChanged;
+  final Future<void> Function(
+    double spacingFt,
+    OrientationKind orientation,
+  ) onShowHistory;
+  final void Function(double spacingFt, OrientationKind orientation) onFocusChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    final spacings = [...site.spacings]
+      ..sort((a, b) => a.spacingFeet.compareTo(b.spacingFeet));
+    double? previousAverage;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        _buildMetadata(context),
+        const Divider(height: 1),
+        Expanded(
+          child: ListView.builder(
+            itemCount: spacings.length,
+            itemBuilder: (context, index) {
+              final record = spacings[index];
+              final aLatest = record.orientationA.latest;
+              final bLatest = record.orientationB.latest;
+              final flags = evaluateQc(
+                spacingFeet: record.spacingFeet,
+                resistanceA: aLatest?.resistanceOhm,
+                resistanceB: bLatest?.resistanceOhm,
+                sdA: aLatest?.standardDeviationPercent,
+                sdB: bLatest?.standardDeviationPercent,
+                config: const QcConfig(),
+                previousRho: previousAverage,
+              );
+              final avg = averageApparentResistivity(record.spacingFeet, [
+                aLatest?.resistanceOhm,
+                bLatest?.resistanceOhm,
+              ]);
+              previousAverage = avg ?? previousAverage;
+              return _SpacingRow(
+                record: record,
+                flags: flags,
+                onResistanceChanged: (orientation, resistance) =>
+                    onResistanceChanged(
+                  record.spacingFeet,
+                  orientation,
+                  resistance,
+                  null,
+                ),
+                onSdChanged: (orientation, sd) => onSdChanged(
+                  record.spacingFeet,
+                  orientation,
+                  sd,
+                ),
+                onNoteChanged: (orientation, note) => onNoteChanged(
+                  record.spacingFeet,
+                  orientation,
+                  note,
+                ),
+                onToggleBad: (orientation, isBad) => onToggleBad(
+                  record.spacingFeet,
+                  orientation,
+                  isBad,
+                ),
+                onShowHistory: (orientation) => onShowHistory(
+                  record.spacingFeet,
+                  orientation,
+                ),
+                onFocusChanged: (orientation) => onFocusChanged(
+                  record.spacingFeet,
+                  orientation,
+                ),
+              );
+            },
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildMetadata(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(12.0),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            site.displayName,
+            style: Theme.of(context).textTheme.titleMedium,
+          ),
+          const SizedBox(height: 12),
+          Row(
+            children: [
+              Expanded(
+                child: TextFormField(
+                  initialValue: site.powerMilliAmps.toStringAsFixed(2),
+                  decoration: const InputDecoration(
+                    labelText: 'Power (mA)',
+                  ),
+                  keyboardType: const TextInputType.numberWithOptions(decimal: true),
+                  onFieldSubmitted: (value) {
+                    final parsed = double.tryParse(value);
+                    if (parsed != null) {
+                      onMetadataChanged(power: parsed);
+                    }
+                  },
+                ),
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: TextFormField(
+                  initialValue: site.stacks.toString(),
+                  decoration: const InputDecoration(labelText: 'Stacks'),
+                  keyboardType: TextInputType.number,
+                  onFieldSubmitted: (value) {
+                    final parsed = int.tryParse(value);
+                    if (parsed != null) {
+                      onMetadataChanged(stacks: parsed);
+                    }
+                  },
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 12),
+          Row(
+            children: [
+              Expanded(
+                child: DropdownButtonFormField<SoilType>(
+                  value: site.soil,
+                  decoration: const InputDecoration(labelText: 'Soil'),
+                  items: SoilType.values
+                      .map(
+                        (soil) => DropdownMenuItem(
+                          value: soil,
+                          child: Text(soil.label),
+                        ),
+                      )
+                      .toList(),
+                  onChanged: (soil) => onMetadataChanged(soil: soil),
+                ),
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: DropdownButtonFormField<MoistureLevel>(
+                  value: site.moisture,
+                  decoration: const InputDecoration(labelText: 'Moisture'),
+                  items: MoistureLevel.values
+                      .map(
+                        (level) => DropdownMenuItem(
+                          value: level,
+                          child: Text(level.label),
+                        ),
+                      )
+                      .toList(),
+                  onChanged: (level) => onMetadataChanged(moisture: level),
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _SpacingRow extends StatelessWidget {
+  const _SpacingRow({
+    required this.record,
+    required this.flags,
+    required this.onResistanceChanged,
+    required this.onSdChanged,
+    required this.onNoteChanged,
+    required this.onToggleBad,
+    required this.onShowHistory,
+    required this.onFocusChanged,
+  });
+
+  final SpacingRecord record;
+  final QcFlags flags;
+  final void Function(OrientationKind orientation, double? resistance)
+      onResistanceChanged;
+  final void Function(OrientationKind orientation, double? sd) onSdChanged;
+  final void Function(OrientationKind orientation, String note) onNoteChanged;
+  final void Function(OrientationKind orientation, bool isBad) onToggleBad;
+  final Future<void> Function(OrientationKind orientation) onShowHistory;
+  final void Function(OrientationKind orientation) onFocusChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    final insideFt = record.tapeInsideFeet;
+    final outsideFt = record.tapeOutsideFeet;
+    return Card(
+      margin: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+      child: Padding(
+        padding: const EdgeInsets.all(12.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Text(
+                  'a = ${record.spacingFeet.toStringAsFixed(1)} ft',
+                  style: Theme.of(context).textTheme.titleMedium,
+                ),
+                const SizedBox(width: 12),
+                Tooltip(
+                  message:
+                      'Inside: ${insideFt.toStringAsFixed(1)} ft (${feetToMeters(insideFt).toStringAsFixed(2)} m)\n'
+                      'Outside: ${outsideFt.toStringAsFixed(1)} ft (${feetToMeters(outsideFt).toStringAsFixed(2)} m)',
+                  child: Chip(
+                    avatar: const Icon(Icons.straighten),
+                    label: Text(
+                        'Inside ${insideFt.toStringAsFixed(1)} ft • Outside ${outsideFt.toStringAsFixed(1)} ft'),
+                  ),
+                ),
+                const Spacer(),
+                if (flags.outlier)
+                  Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 4.0),
+                    child: Chip(
+                      label: const Text('Outlier'),
+                      backgroundColor: Theme.of(context).colorScheme.errorContainer,
+                    ),
+                  ),
+                if (flags.highVariance)
+                  Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 4.0),
+                    child: Chip(
+                      label: const Text('High %SD'),
+                      backgroundColor: Theme.of(context).colorScheme.tertiaryContainer,
+                    ),
+                  ),
+                if (flags.anisotropy)
+                  Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 4.0),
+                    child: Chip(
+                      label: const Text('Anisotropy'),
+                      backgroundColor: Theme.of(context).colorScheme.secondaryContainer,
+                    ),
+                  ),
+                if (flags.jump)
+                  Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 4.0),
+                    child: Chip(
+                      label: const Text('Jump'),
+                      backgroundColor: Theme.of(context).colorScheme.primaryContainer,
+                    ),
+                  ),
+              ],
+            ),
+            const SizedBox(height: 12),
+            Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Expanded(
+                  child: _OrientationCell(
+                    history: record.orientationA,
+                    onFocus: () => onFocusChanged(OrientationKind.a),
+                    onResistanceChanged: (value) =>
+                        onResistanceChanged(OrientationKind.a, value),
+                    onSdChanged: (value) => onSdChanged(OrientationKind.a, value),
+                    onNoteChanged: (value) => onNoteChanged(OrientationKind.a, value),
+                    onToggleBad: (value) => onToggleBad(OrientationKind.a, value),
+                    onShowHistory: () => onShowHistory(OrientationKind.a),
+                  ),
+                ),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: _OrientationCell(
+                    history: record.orientationB,
+                    onFocus: () => onFocusChanged(OrientationKind.b),
+                    onResistanceChanged: (value) =>
+                        onResistanceChanged(OrientationKind.b, value),
+                    onSdChanged: (value) => onSdChanged(OrientationKind.b, value),
+                    onNoteChanged: (value) => onNoteChanged(OrientationKind.b, value),
+                    onToggleBad: (value) => onToggleBad(OrientationKind.b, value),
+                    onShowHistory: () => onShowHistory(OrientationKind.b),
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _OrientationCell extends StatefulWidget {
+  const _OrientationCell({
+    required this.history,
+    required this.onFocus,
+    required this.onResistanceChanged,
+    required this.onSdChanged,
+    required this.onNoteChanged,
+    required this.onToggleBad,
+    required this.onShowHistory,
+  });
+
+  final DirectionReadingHistory history;
+  final VoidCallback onFocus;
+  final ValueChanged<double?> onResistanceChanged;
+  final ValueChanged<double?> onSdChanged;
+  final ValueChanged<String> onNoteChanged;
+  final ValueChanged<bool> onToggleBad;
+  final Future<void> Function() onShowHistory;
+
+  @override
+  State<_OrientationCell> createState() => _OrientationCellState();
+}
+
+class _OrientationCellState extends State<_OrientationCell> {
+  late TextEditingController _resistanceController;
+  late TextEditingController _sdController;
+  late FocusNode _resistanceFocus;
+  late FocusNode _sdFocus;
+
+  @override
+  void initState() {
+    super.initState();
+    _resistanceController = TextEditingController(
+      text: widget.history.latest?.resistanceOhm?.toStringAsFixed(2) ?? '',
+    );
+    _sdController = TextEditingController(
+      text: widget.history.latest?.standardDeviationPercent?.toStringAsFixed(1) ?? '',
+    );
+    _resistanceFocus = FocusNode();
+    _sdFocus = FocusNode();
+    _resistanceFocus.addListener(_handleFocus);
+    _sdFocus.addListener(_handleFocus);
+  }
+
+  @override
+  void didUpdateWidget(covariant _OrientationCell oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.history.latest?.timestamp != oldWidget.history.latest?.timestamp) {
+      _resistanceController.text =
+          widget.history.latest?.resistanceOhm?.toStringAsFixed(2) ?? '';
+      _sdController.text =
+          widget.history.latest?.standardDeviationPercent?.toStringAsFixed(1) ?? '';
+    }
+  }
+
+  @override
+  void dispose() {
+    _resistanceFocus.removeListener(_handleFocus);
+    _sdFocus.removeListener(_handleFocus);
+    _resistanceFocus.dispose();
+    _sdFocus.dispose();
+    _resistanceController.dispose();
+    _sdController.dispose();
+    super.dispose();
+  }
+
+  void _handleFocus() {
+    if (_resistanceFocus.hasFocus || _sdFocus.hasFocus) {
+      widget.onFocus();
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final latest = widget.history.latest;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          widget.history.label,
+          style: Theme.of(context).textTheme.titleSmall,
+        ),
+        const SizedBox(height: 8),
+        TextFormField(
+          controller: _resistanceController,
+          focusNode: _resistanceFocus,
+          decoration: const InputDecoration(labelText: 'R (Ω)'),
+          keyboardType: const TextInputType.numberWithOptions(decimal: true),
+          onFieldSubmitted: (value) {
+            widget.onResistanceChanged(double.tryParse(value));
+          },
+        ),
+        const SizedBox(height: 8),
+        TextFormField(
+          controller: _sdController,
+          focusNode: _sdFocus,
+          decoration: const InputDecoration(labelText: '%SD'),
+          keyboardType: const TextInputType.numberWithOptions(decimal: true),
+          onFieldSubmitted: (value) {
+            widget.onSdChanged(double.tryParse(value));
+          },
+        ),
+        Row(
+          children: [
+            Checkbox(
+              value: latest?.isBad ?? false,
+              onChanged: (value) {
+                widget.onToggleBad(value ?? false);
+              },
+            ),
+            const Text('Bad'),
+            const Spacer(),
+            IconButton(
+              icon: const Icon(Icons.note_alt),
+              tooltip: 'Edit note',
+              onPressed: () async {
+                final controller = TextEditingController(text: latest?.note ?? '');
+                final note = await showDialog<String>(
+                  context: context,
+                  builder: (context) => AlertDialog(
+                    title: Text('Note — ${widget.history.label}'),
+                    content: TextField(
+                      controller: controller,
+                      decoration: const InputDecoration(labelText: 'Note'),
+                      maxLines: 3,
+                    ),
+                    actions: [
+                      TextButton(
+                        onPressed: () => Navigator.of(context).pop(latest?.note ?? ''),
+                        child: const Text('Cancel'),
+                      ),
+                      FilledButton(
+                        onPressed: () =>
+                            Navigator.of(context).pop(controller.text.trim()),
+                        child: const Text('Save'),
+                      ),
+                    ],
+                  ),
+                );
+                if (note != null) {
+                  widget.onNoteChanged(note);
+                }
+              },
+            ),
+            IconButton(
+              icon: const Icon(Icons.history),
+              tooltip: 'Re-read history',
+              onPressed: widget.onShowHistory,
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,6 +24,7 @@ flutter:
   uses-material-design: true
   assets:
     - assets/samples/
+    - assets/templates/
 
 dev_dependencies:
   flutter_test:

--- a/test/calc_test.dart
+++ b/test/calc_test.dart
@@ -1,0 +1,36 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:ves_qc/models/calc.dart';
+
+void main() {
+  test('feet to meters conversion', () {
+    expect(feetToMeters(10), closeTo(3.048, 1e-6));
+    expect(metersToFeet(3.048), closeTo(10, 1e-6));
+  });
+
+  test('rho a wenner calculation matches expected value', () {
+    final rho = rhoAWenner(20, 50);
+    expect(rho, closeTo(1915, 20));
+  });
+
+  test('QC flags detect high variability', () {
+    final flags = evaluateQc(
+      spacingFeet: 10,
+      resistanceA: 100,
+      resistanceB: 105,
+      sdA: 20,
+      sdB: 5,
+      config: const QcConfig(sdThresholdPercent: 10),
+      previousRho: null,
+    );
+    expect(flags.highVariance, isTrue);
+    expect(flags.outlier, isFalse);
+  });
+
+  test('depth cue computed as half spacing', () {
+    final feet = computeDepthCueFeet([10, 20, 40]);
+    expect(feet, [5, 10, 20]);
+    final meters = computeDepthCueMeters([10]);
+    expect(meters.first, closeTo(1.524, 1e-6));
+  });
+}

--- a/test/export_test.dart
+++ b/test/export_test.dart
@@ -1,0 +1,83 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:ves_qc/models/direction_reading.dart';
+import 'package:ves_qc/models/project.dart';
+import 'package:ves_qc/models/site.dart';
+import 'package:ves_qc/services/export_service.dart';
+import 'package:ves_qc/services/storage_service.dart';
+
+void main() {
+  test('CSV exporter writes ordered spacings', () async {
+    final tempDir = await Directory.systemTemp.createTemp('resicheck_test');
+    final storage = ProjectStorageService(overrideRoot: tempDir);
+    final project = ProjectRecord.newProject(
+      projectId: 'p1',
+      projectName: 'Export Test',
+      canonicalSpacingsFeet: const [2.5, 5, 10],
+    );
+    final site = SiteRecord(
+      siteId: 'SiteA',
+      displayName: 'Site A',
+      spacings: [
+        SpacingRecord(
+          spacingFeet: 10,
+          orientationA: DirectionReadingHistory(
+            orientation: OrientationKind.a,
+            label: 'N–S',
+            samples: [
+              DirectionReadingSample(
+                timestamp: DateTime.now(),
+                resistanceOhm: 50,
+              ),
+            ],
+          ),
+          orientationB: DirectionReadingHistory(
+            orientation: OrientationKind.b,
+            label: 'W–E',
+            samples: [
+              DirectionReadingSample(
+                timestamp: DateTime.now(),
+                resistanceOhm: 55,
+              ),
+            ],
+          ),
+        ),
+        SpacingRecord(
+          spacingFeet: 5,
+          orientationA: DirectionReadingHistory(
+            orientation: OrientationKind.a,
+            label: 'N–S',
+            samples: [
+              DirectionReadingSample(
+                timestamp: DateTime.now(),
+                resistanceOhm: 45,
+              ),
+            ],
+          ),
+          orientationB: DirectionReadingHistory(
+            orientation: OrientationKind.b,
+            label: 'W–E',
+            samples: [
+              DirectionReadingSample(
+                timestamp: DateTime.now(),
+                resistanceOhm: 44,
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+    final storageProject = await storage.saveProject(project);
+    final exportService = ExportService(storage);
+    final csvFile = await exportService.exportFieldCsv(storageProject, site);
+    final lines = await csvFile.readAsLines();
+    expect(lines.length, greaterThan(1));
+    // After header the first data row should be spacing 5 ft because of ordering.
+    expect(lines[1].contains(',5,'), isTrue);
+    final datFile = await exportService.exportSurferDat(storageProject, site);
+    final datLines = await datFile.readAsLines();
+    expect(datLines.last.startsWith('10'), isTrue);
+  });
+}

--- a/test/ui_update_test.dart
+++ b/test/ui_update_test.dart
@@ -1,0 +1,46 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:ves_qc/models/direction_reading.dart';
+import 'package:ves_qc/models/site.dart';
+import 'package:ves_qc/ui/project_workflow/plots_panel.dart';
+
+void main() {
+  test('marking reading bad removes it from plot when outliers hidden', () {
+    final site = SiteRecord(
+      siteId: 'SiteA',
+      displayName: 'Site A',
+      spacings: [
+        SpacingRecord(
+          spacingFeet: 20,
+          orientationA: DirectionReadingHistory(
+            orientation: OrientationKind.a,
+            label: 'N–S',
+            samples: [
+              DirectionReadingSample(
+                timestamp: DateTime.now(),
+                resistanceOhm: 100,
+                isBad: true,
+              ),
+            ],
+          ),
+          orientationB: DirectionReadingHistory(
+            orientation: OrientationKind.b,
+            label: 'W–E',
+            samples: [
+              DirectionReadingSample(
+                timestamp: DateTime.now(),
+                resistanceOhm: 95,
+                isBad: false,
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+    final hidden = buildSeriesForSite(site, showOutliers: false);
+    expect(hidden.aSeries, isEmpty);
+    expect(hidden.bSeries.length, 1);
+    final shown = buildSeriesForSite(site, showOutliers: true);
+    expect(shown.aSeries.length, 1);
+  });
+}


### PR DESCRIPTION
## Summary
- add project, site, and reading models with deterministic Wenner calculations and QC helpers
- implement project storage, autosave, export pipelines, and bundled ghost/template assets
- build split-pane project workflow UI with plots, table entry, depth sketch, shortcuts, and update the README

## Testing
- not run (Flutter/Dart tooling unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68e667f6563c832ea024ab5e308c9a1f