### PR TITLE
Fix QC threshold boundaries and clean analyzer warnings

### DIFF
--- a/lib/services/qc_rules.dart
+++ b/lib/services/qc_rules.dart
@@ -33,13 +33,13 @@ QaLevel classifyPoint({
   final maxContact = point.contactRMax ?? 0;
 
   bool isRed() =>
-      cv > kQaYellowCvLimit ||
-      absResidual > kQaYellowResidualLimit ||
-      spDrift > kQaSpLimitMv ||
-      maxContact > kQaContactLimitOhm;
+      cv >= kQaYellowCvLimit ||
+      absResidual >= kQaYellowResidualLimit ||
+      spDrift >= kQaSpLimitMv ||
+      maxContact >= kQaContactLimitOhm;
   bool isYellow() =>
-      (cv > kQaGreenCvLimit && cv <= kQaYellowCvLimit) ||
-      (absResidual > kQaGreenResidualLimit && absResidual <= kQaYellowResidualLimit);
+      (cv >= kQaGreenCvLimit && cv < kQaYellowCvLimit) ||
+      (absResidual >= kQaGreenResidualLimit && absResidual < kQaYellowResidualLimit);
 
   if (isRed()) return QaLevel.red;
   if (point.hasRhoQaWarning) return QaLevel.yellow;

--- a/lib/services/storage_service.dart
+++ b/lib/services/storage_service.dart
@@ -20,11 +20,12 @@ class ProjectStorageService {
   final _uuid = const Uuid();
 
   Future<Directory> _ensureRoot() async {
-    if (_overrideRoot != null) {
-      if (!await _overrideRoot!.exists()) {
-        await _overrideRoot!.create(recursive: true);
+    final overrideRoot = _overrideRoot;
+    if (overrideRoot != null) {
+      if (!await overrideRoot.exists()) {
+        await overrideRoot.create(recursive: true);
       }
-      return _overrideRoot!;
+      return overrideRoot;
     }
     final docs = await getApplicationDocumentsDirectory();
     final root = Directory(p.join(docs.path, 'ResiCheckProjects'));

--- a/lib/ui/project_workflow/plots_panel.dart
+++ b/lib/ui/project_workflow/plots_panel.dart
@@ -107,7 +107,7 @@ class PlotsPanel extends StatelessWidget {
         lineTouchData: LineTouchData(
           touchTooltipData: LineTouchTooltipData(
             tooltipBgColor: Theme.of(context).colorScheme.surface.withValues(
-                  alpha: (0.9 * 255).round(),
+                  alpha: (0.9 * 255).round().toDouble(),
                 ),
             getTooltipItems: (touchedSpots) {
               return touchedSpots.map((spot) {

--- a/lib/ui/project_workflow/project_shell.dart
+++ b/lib/ui/project_workflow/project_shell.dart
@@ -402,7 +402,7 @@ class _ProjectShellState extends State<ProjectShell> {
     }
     try {
       final csvFile = await _exportService.exportFieldCsv(_project, site);
-      final datFile = await _exportService.exportSurferDat(_project, site);
+      await _exportService.exportSurferDat(_project, site);
       if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(

--- a/test/qc_rules_test.dart
+++ b/test/qc_rules_test.dart
@@ -53,6 +53,16 @@ void main() {
     expect(level, QaLevel.red);
   });
 
+  test('Red classification when hitting yellow residual threshold', () {
+    final point = _makePoint(110.0, sigma: kQaGreenCvLimit * 110.0);
+    final level = classifyPoint(
+      residual: kQaYellowResidualLimit,
+      coefficientOfVariation: kQaGreenCvLimit / 2,
+      point: point,
+    );
+    expect(level, QaLevel.red);
+  });
+
   test('Summary counts', () {
     final points = [
       _makePoint(100.0, sigma: 2.0),


### PR DESCRIPTION
## Summary
- ensure the plots panel tooltip alpha passes a double to `Color.withValues`
- adjust QC threshold comparisons so boundary values promote to yellow/red and cover them in tests
- resolve analyzer warnings by dropping the unused DAT export handle and avoiding nullable overrides

## Testing
- not run (environment lacks Flutter SDK)


------
https://chatgpt.com/codex/tasks/task_e_68e6739d24c4832e8deaf0e78c6e196b