### PR TITLE
feat: redesign table panel and improve QC handling

### DIFF
--- a/lib/services/qc_rules.dart
+++ b/lib/services/qc_rules.dart
@@ -38,8 +38,8 @@ QaLevel classifyPoint({
       spDrift >= kQaSpLimitMv ||
       maxContact >= kQaContactLimitOhm;
   bool isYellow() =>
-      (cv >= kQaGreenCvLimit && cv < kQaYellowCvLimit) ||
-      (absResidual >= kQaGreenResidualLimit && absResidual < kQaYellowResidualLimit);
+      (cv > kQaGreenCvLimit && cv < kQaYellowCvLimit) ||
+      (absResidual > kQaGreenResidualLimit && absResidual < kQaYellowResidualLimit);
 
   if (isRed()) return QaLevel.red;
   if (point.hasRhoQaWarning) return QaLevel.yellow;

--- a/lib/ui/project_workflow/plots_panel.dart
+++ b/lib/ui/project_workflow/plots_panel.dart
@@ -219,17 +219,14 @@ class PlotsPanel extends StatelessWidget {
   }
 
   Iterable<double> _collectRho(SiteRecord site) sync* {
-    final qcConfig = const QcConfig();
     for (final spacing in site.spacings) {
       for (final orientation in [spacing.orientationA, spacing.orientationB]) {
         final latest = orientation.latest;
         if (latest == null || latest.resistanceOhm == null) {
           continue;
         }
-        final outlier = latest.isBad ||
-            (!showOutliers &&
-                latest.resistanceOhm!.abs() > qcConfig.outlierCapOhm);
-        if (outlier) {
+        final hideSample = !showOutliers && (latest.isBad);
+        if (hideSample) {
           continue;
         }
         yield rhoAWenner(spacing.spacingFeet, latest.resistanceOhm!);
@@ -248,17 +245,14 @@ class SeriesData {
 }
 
 SeriesData buildSeriesForSite(SiteRecord site, {required bool showOutliers}) {
-  final qcConfig = const QcConfig();
   final aSpots = <FlSpot>[];
   final bSpots = <FlSpot>[];
   for (final spacing in site.spacings) {
     final aSample = spacing.orientationA.latest;
     final bSample = spacing.orientationB.latest;
     if (aSample != null && aSample.resistanceOhm != null) {
-      final outlier = aSample.isBad ||
-          (!showOutliers &&
-              (aSample.resistanceOhm!.abs() > qcConfig.outlierCapOhm));
-      if (!outlier) {
+      final hideSample = !showOutliers && aSample.isBad;
+      if (!hideSample) {
         aSpots.add(
           FlSpot(
             math.log(spacing.spacingFeet) / math.ln10,
@@ -269,10 +263,8 @@ SeriesData buildSeriesForSite(SiteRecord site, {required bool showOutliers}) {
       }
     }
     if (bSample != null && bSample.resistanceOhm != null) {
-      final outlier = bSample.isBad ||
-          (!showOutliers &&
-              (bSample.resistanceOhm!.abs() > qcConfig.outlierCapOhm));
-      if (!outlier) {
+      final hideSample = !showOutliers && bSample.isBad;
+      if (!hideSample) {
         bSpots.add(
           FlSpot(
             math.log(spacing.spacingFeet) / math.ln10,

--- a/lib/ui/project_workflow/table_panel.dart
+++ b/lib/ui/project_workflow/table_panel.dart
@@ -4,13 +4,14 @@ import '../../models/calc.dart';
 import '../../models/direction_reading.dart';
 import '../../models/site.dart';
 
-class TablePanel extends StatelessWidget {
+class TablePanel extends StatefulWidget {
   const TablePanel({
     super.key,
     required this.site,
+    required this.showOutliers,
     required this.onResistanceChanged,
     required this.onSdChanged,
-    required this.onNoteChanged,
+    required this.onInterpretationChanged,
     required this.onToggleBad,
     required this.onMetadataChanged,
     required this.onShowHistory,
@@ -18,6 +19,7 @@ class TablePanel extends StatelessWidget {
   });
 
   final SiteRecord site;
+  final bool showOutliers;
   final void Function(
     double spacingFt,
     OrientationKind orientation,
@@ -29,11 +31,8 @@ class TablePanel extends StatelessWidget {
     OrientationKind orientation,
     double? sd,
   ) onSdChanged;
-  final void Function(
-    double spacingFt,
-    OrientationKind orientation,
-    String note,
-  ) onNoteChanged;
+  final void Function(double spacingFt, String interpretation)
+      onInterpretationChanged;
   final void Function(
     double spacingFt,
     OrientationKind orientation,
@@ -52,77 +51,479 @@ class TablePanel extends StatelessWidget {
   final void Function(double spacingFt, OrientationKind orientation) onFocusChanged;
 
   @override
+  State<TablePanel> createState() => _TablePanelState();
+}
+
+enum _FieldType { resistance, sd, interpretation }
+
+class _FieldKey {
+  _FieldKey({
+    required this.spacingFeet,
+    required this.orientation,
+    required this.type,
+  }) : spacingHash = (spacingFeet * 1000).round();
+
+  final double spacingFeet;
+  final int spacingHash;
+  final OrientationKind? orientation;
+  final _FieldType type;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is _FieldKey &&
+        spacingHash == other.spacingHash &&
+        orientation == other.orientation &&
+        type == other.type;
+  }
+
+  @override
+  int get hashCode => Object.hash(spacingHash, orientation, type);
+}
+
+class _RowConfig {
+  _RowConfig({
+    required this.record,
+    required this.flags,
+    required this.aSample,
+    required this.bSample,
+    required this.hideA,
+    required this.hideB,
+    required this.sdWarningA,
+    required this.sdWarningB,
+    required this.insideFeet,
+    required this.insideMeters,
+    required this.outsideFeet,
+    required this.outsideMeters,
+    required this.aResKey,
+    required this.aSdKey,
+    required this.bResKey,
+    required this.bSdKey,
+    required this.interpretationKey,
+  });
+
+  final SpacingRecord record;
+  final QcFlags flags;
+  final DirectionReadingSample? aSample;
+  final DirectionReadingSample? bSample;
+  final bool hideA;
+  final bool hideB;
+  final bool sdWarningA;
+  final bool sdWarningB;
+  final double insideFeet;
+  final double insideMeters;
+  final double outsideFeet;
+  final double outsideMeters;
+  final _FieldKey aResKey;
+  final _FieldKey aSdKey;
+  final _FieldKey bResKey;
+  final _FieldKey bSdKey;
+  final _FieldKey interpretationKey;
+}
+
+class _TablePanelState extends State<TablePanel> {
+  final Map<_FieldKey, TextEditingController> _controllers = {};
+  final Map<_FieldKey, FocusNode> _focusNodes = {};
+  Map<_FieldKey, _FieldKey?> _tabOrder = {};
+
+  @override
+  void dispose() {
+    for (final controller in _controllers.values) {
+      controller.dispose();
+    }
+    for (final focusNode in _focusNodes.values) {
+      focusNode.dispose();
+    }
+    super.dispose();
+  }
+  @override
   Widget build(BuildContext context) {
-    final spacings = [...site.spacings]
+    final spacings = [...widget.site.spacings]
       ..sort((a, b) => a.spacingFeet.compareTo(b.spacingFeet));
+
+    final qcConfig = const QcConfig();
+    final rowConfigs = <_RowConfig>[];
+    final requiredKeys = <_FieldKey>[];
+    final values = <_FieldKey, String>{};
+    final focusOrder = <_FieldKey>[];
     double? previousAverage;
+
+    for (final record in spacings) {
+      final aValid = record.orientationA.latest;
+      final bValid = record.orientationB.latest;
+      final aSample = _latestSample(record.orientationA);
+      final bSample = _latestSample(record.orientationB);
+      final flags = evaluateQc(
+        spacingFeet: record.spacingFeet,
+        resistanceA: aValid?.resistanceOhm,
+        resistanceB: bValid?.resistanceOhm,
+        sdA: aValid?.standardDeviationPercent,
+        sdB: bValid?.standardDeviationPercent,
+        config: qcConfig,
+        previousRho: previousAverage,
+      );
+      final avg = averageApparentResistivity(record.spacingFeet, [
+        aValid?.resistanceOhm,
+        bValid?.resistanceOhm,
+      ]);
+      previousAverage = avg ?? previousAverage;
+
+      final aResKey = _FieldKey(
+        spacingFeet: record.spacingFeet,
+        orientation: OrientationKind.a,
+        type: _FieldType.resistance,
+      );
+      final aSdKey = _FieldKey(
+        spacingFeet: record.spacingFeet,
+        orientation: OrientationKind.a,
+        type: _FieldType.sd,
+      );
+      final bResKey = _FieldKey(
+        spacingFeet: record.spacingFeet,
+        orientation: OrientationKind.b,
+        type: _FieldType.resistance,
+      );
+      final bSdKey = _FieldKey(
+        spacingFeet: record.spacingFeet,
+        orientation: OrientationKind.b,
+        type: _FieldType.sd,
+      );
+      final interpretationKey = _FieldKey(
+        spacingFeet: record.spacingFeet,
+        orientation: null,
+        type: _FieldType.interpretation,
+      );
+
+      requiredKeys
+        ..add(aResKey)
+        ..add(aSdKey)
+        ..add(bResKey)
+        ..add(bSdKey)
+        ..add(interpretationKey);
+
+      values[aResKey] = _formatResistance(aSample?.resistanceOhm);
+      values[aSdKey] = _formatSd(aSample?.standardDeviationPercent);
+      values[bResKey] = _formatResistance(bSample?.resistanceOhm);
+      values[bSdKey] = _formatSd(bSample?.standardDeviationPercent);
+      final interpretationText =
+          record.interpretation ?? record.computeAutoInterpretation() ?? '';
+      values[interpretationKey] = interpretationText;
+
+      focusOrder
+        ..add(aResKey)
+        ..add(aSdKey)
+        ..add(bResKey)
+        ..add(bSdKey);
+
+      final hideA = !widget.showOutliers && (aSample?.isBad ?? false);
+      final hideB = !widget.showOutliers && (bSample?.isBad ?? false);
+      final sdWarningA =
+          (aSample?.standardDeviationPercent ?? 0) > qcConfig.sdThresholdPercent;
+      final sdWarningB =
+          (bSample?.standardDeviationPercent ?? 0) > qcConfig.sdThresholdPercent;
+
+      rowConfigs.add(
+        _RowConfig(
+          record: record,
+          flags: flags,
+          aSample: aSample,
+          bSample: bSample,
+          hideA: hideA,
+          hideB: hideB,
+          sdWarningA: sdWarningA,
+          sdWarningB: sdWarningB,
+          insideFeet: record.tapeInsideFeet,
+          insideMeters: record.tapeInsideMeters,
+          outsideFeet: record.tapeOutsideFeet,
+          outsideMeters: record.tapeOutsideMeters,
+          aResKey: aResKey,
+          aSdKey: aSdKey,
+          bResKey: bResKey,
+          bSdKey: bSdKey,
+          interpretationKey: interpretationKey,
+        ),
+      );
+    }
+
+    _syncControllers(requiredKeys, values);
+    _tabOrder = {};
+    for (var i = 0; i < focusOrder.length; i++) {
+      final current = focusOrder[i];
+      final next = i + 1 < focusOrder.length ? focusOrder[i + 1] : null;
+      _tabOrder[current] = next;
+    }
+
+    final theme = Theme.of(context);
+    final orientationALabel =
+        spacings.isEmpty ? 'N–S' : spacings.first.orientationA.label;
+    final orientationBLabel =
+        spacings.isEmpty ? 'W–E' : spacings.first.orientationB.label;
+
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         _buildMetadata(context),
         const Divider(height: 1),
         Expanded(
-          child: ListView.builder(
-            itemCount: spacings.length,
-            itemBuilder: (context, index) {
-              final record = spacings[index];
-              final aLatest = record.orientationA.latest;
-              final bLatest = record.orientationB.latest;
-              final flags = evaluateQc(
-                spacingFeet: record.spacingFeet,
-                resistanceA: aLatest?.resistanceOhm,
-                resistanceB: bLatest?.resistanceOhm,
-                sdA: aLatest?.standardDeviationPercent,
-                sdB: bLatest?.standardDeviationPercent,
-                config: const QcConfig(),
-                previousRho: previousAverage,
-              );
-              final avg = averageApparentResistivity(record.spacingFeet, [
-                aLatest?.resistanceOhm,
-                bLatest?.resistanceOhm,
-              ]);
-              previousAverage = avg ?? previousAverage;
-              return _SpacingRow(
-                record: record,
-                flags: flags,
-                onResistanceChanged: (orientation, resistance) =>
-                    onResistanceChanged(
-                  record.spacingFeet,
-                  orientation,
-                  resistance,
-                  null,
+          child: spacings.isEmpty
+              ? Center(
+                  child: Text(
+                    'No spacings configured for this site.',
+                    style: theme.textTheme.bodyMedium,
+                  ),
+                )
+              : _buildTable(
+                  context,
+                  theme,
+                  rowConfigs,
+                  orientationALabel,
+                  orientationBLabel,
                 ),
-                onSdChanged: (orientation, sd) => onSdChanged(
-                  record.spacingFeet,
-                  orientation,
-                  sd,
-                ),
-                onNoteChanged: (orientation, note) => onNoteChanged(
-                  record.spacingFeet,
-                  orientation,
-                  note,
-                ),
-                onToggleBad: (orientation, isBad) => onToggleBad(
-                  record.spacingFeet,
-                  orientation,
-                  isBad,
-                ),
-                onShowHistory: (orientation) => onShowHistory(
-                  record.spacingFeet,
-                  orientation,
-                ),
-                onFocusChanged: (orientation) => onFocusChanged(
-                  record.spacingFeet,
-                  orientation,
-                ),
-              );
-            },
-          ),
         ),
       ],
     );
   }
+  Widget _buildTable(
+    BuildContext context,
+    ThemeData theme,
+    List<_RowConfig> rows,
+    String orientationALabel,
+    String orientationBLabel,
+  ) {
+    return Scrollbar(
+      thumbVisibility: true,
+      child: SingleChildScrollView(
+        scrollDirection: Axis.vertical,
+        child: SingleChildScrollView(
+          scrollDirection: Axis.horizontal,
+          child: DataTable(
+            headingTextStyle:
+                theme.textTheme.labelMedium?.copyWith(fontWeight: FontWeight.bold),
+            dataRowMinHeight: 76,
+            dataRowMaxHeight: 120,
+            columns: [
+              const DataColumn(label: Text('a-spacing (ft)')),
+              DataColumn(label: Text('Res $orientationALabel (Ω)')),
+              const DataColumn(label: Text('SD (%)')),
+              DataColumn(label: Text('Res $orientationBLabel (Ω)')),
+              const DataColumn(label: Text('SD (%)')),
+              const DataColumn(label: Text('Interpretation')),
+            ],
+            rows: rows.map((row) => _buildDataRow(context, theme, row)).toList(),
+          ),
+        ),
+      ),
+    );
+  }
 
+  DataRow _buildDataRow(BuildContext context, ThemeData theme, _RowConfig row) {
+    final color = row.flags.outlier
+        ? MaterialStatePropertyAll(
+            theme.colorScheme.errorContainer.withOpacity(0.35),
+          )
+        : null;
+
+    return DataRow(
+      color: color,
+      cells: [
+        DataCell(_buildSpacingCell(theme, row)),
+        DataCell(
+          _buildResistanceCell(
+            theme,
+            row,
+            row.aResKey,
+            row.aSample,
+            OrientationKind.a,
+            row.hideA,
+          ),
+        ),
+        DataCell(
+          _buildSdCell(
+            theme,
+            row,
+            row.aSdKey,
+            row.hideA,
+            row.sdWarningA,
+          ),
+        ),
+        DataCell(
+          _buildResistanceCell(
+            theme,
+            row,
+            row.bResKey,
+            row.bSample,
+            OrientationKind.b,
+            row.hideB,
+          ),
+        ),
+        DataCell(
+          _buildSdCell(
+            theme,
+            row,
+            row.bSdKey,
+            row.hideB,
+            row.sdWarningB,
+          ),
+        ),
+        DataCell(_buildInterpretationCell(row)),
+      ],
+    );
+  }
+
+  Widget _buildSpacingCell(ThemeData theme, _RowConfig row) {
+    final spacingText = row.record.spacingFeet.toStringAsFixed(2);
+    final tooltip =
+        'Inside: ${row.insideFeet.toStringAsFixed(2)} ft (${row.insideMeters.toStringAsFixed(2)} m)\n'
+        'Outside: ${row.outsideFeet.toStringAsFixed(2)} ft (${row.outsideMeters.toStringAsFixed(2)} m)';
+
+    return Tooltip(
+      message: tooltip,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text('$spacingText ft', style: theme.textTheme.bodyMedium),
+          const SizedBox(height: 4),
+          Text(
+            'Inside ${row.insideFeet.toStringAsFixed(2)} ft • Outside ${row.outsideFeet.toStringAsFixed(2)} ft',
+            style: theme.textTheme.bodySmall,
+          ),
+        ],
+      ),
+    );
+  }
+  Widget _buildResistanceCell(
+    ThemeData theme,
+    _RowConfig row,
+    _FieldKey key,
+    DirectionReadingSample? sample,
+    OrientationKind orientation,
+    bool hide,
+  ) {
+    final controller = _controllers[key]!;
+    final focusNode = _focusNodes[key]!;
+    final isBad = sample?.isBad ?? false;
+    final label = orientation == OrientationKind.a
+        ? row.record.orientationA.label
+        : row.record.orientationB.label;
+
+    return Opacity(
+      opacity: hide ? 0.45 : 1.0,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text(label, style: theme.textTheme.labelSmall),
+          TextField(
+            controller: controller,
+            focusNode: focusNode,
+            enabled: !hide,
+            keyboardType: const TextInputType.numberWithOptions(decimal: true),
+            textInputAction: TextInputAction.next,
+            decoration: InputDecoration(
+              border: InputBorder.none,
+              isDense: true,
+              hintText: hide ? 'Hidden while outliers hidden' : null,
+              contentPadding: EdgeInsets.zero,
+            ),
+            onSubmitted: (value) => _submitResistance(key, value),
+            onEditingComplete: () => _submitResistance(key, controller.text),
+          ),
+          Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Tooltip(
+                message: isBad
+                    ? 'Marked bad — tap to clear flag'
+                    : 'Mark reading bad',
+                child: Checkbox(
+                  value: isBad,
+                  onChanged: sample == null
+                      ? null
+                      : (value) => widget.onToggleBad(
+                            row.record.spacingFeet,
+                            orientation,
+                            value ?? false,
+                          ),
+                  materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                  visualDensity: VisualDensity.compact,
+                ),
+              ),
+              IconButton(
+                icon: const Icon(Icons.history, size: 18),
+                tooltip: 'Show $label history',
+                onPressed: () => widget.onShowHistory(
+                  row.record.spacingFeet,
+                  orientation,
+                ),
+              ),
+            ],
+          ),
+          if (isBad)
+            Text(
+              'Marked bad',
+              style: theme.textTheme.labelSmall?.copyWith(
+                color: theme.colorScheme.error,
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildSdCell(
+    ThemeData theme,
+    _RowConfig row,
+    _FieldKey key,
+    bool hide,
+    bool warning,
+  ) {
+    final controller = _controllers[key]!;
+    final focusNode = _focusNodes[key]!;
+    return Opacity(
+      opacity: hide ? 0.45 : 1.0,
+      child: TextField(
+        controller: controller,
+        focusNode: focusNode,
+        enabled: !hide,
+        keyboardType: const TextInputType.numberWithOptions(decimal: true),
+        textInputAction: TextInputAction.next,
+        decoration: InputDecoration(
+          border: InputBorder.none,
+          isDense: true,
+          contentPadding: EdgeInsets.zero,
+          suffixText: warning ? '⚠' : null,
+          suffixStyle: theme.textTheme.labelMedium?.copyWith(
+            color: theme.colorScheme.error,
+          ),
+        ),
+        onSubmitted: (value) => _submitSd(key, value),
+        onEditingComplete: () => _submitSd(key, controller.text),
+      ),
+    );
+  }
+
+  Widget _buildInterpretationCell(_RowConfig row) {
+    final controller = _controllers[row.interpretationKey]!;
+    final focusNode = _focusNodes[row.interpretationKey]!;
+    return TextField(
+      controller: controller,
+      focusNode: focusNode,
+      maxLines: 2,
+      textInputAction: TextInputAction.done,
+      decoration: const InputDecoration(
+        border: InputBorder.none,
+        isDense: true,
+        hintText: 'Add interpretation notes',
+      ),
+      onSubmitted: (value) =>
+          widget.onInterpretationChanged(row.record.spacingFeet, value),
+      onEditingComplete: () => widget.onInterpretationChanged(
+        row.record.spacingFeet,
+        controller.text,
+      ),
+    );
+  }
   Widget _buildMetadata(BuildContext context) {
     return Padding(
       padding: const EdgeInsets.all(12.0),
@@ -130,7 +531,7 @@ class TablePanel extends StatelessWidget {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           Text(
-            site.displayName,
+            widget.site.displayName,
             style: Theme.of(context).textTheme.titleMedium,
           ),
           const SizedBox(height: 12),
@@ -138,7 +539,7 @@ class TablePanel extends StatelessWidget {
             children: [
               Expanded(
                 child: TextFormField(
-                  initialValue: site.powerMilliAmps.toStringAsFixed(2),
+                  initialValue: widget.site.powerMilliAmps.toStringAsFixed(2),
                   decoration: const InputDecoration(
                     labelText: 'Power (mA)',
                   ),
@@ -146,7 +547,7 @@ class TablePanel extends StatelessWidget {
                   onFieldSubmitted: (value) {
                     final parsed = double.tryParse(value);
                     if (parsed != null) {
-                      onMetadataChanged(power: parsed);
+                      widget.onMetadataChanged(power: parsed);
                     }
                   },
                 ),
@@ -154,13 +555,13 @@ class TablePanel extends StatelessWidget {
               const SizedBox(width: 12),
               Expanded(
                 child: TextFormField(
-                  initialValue: site.stacks.toString(),
+                  initialValue: widget.site.stacks.toString(),
                   decoration: const InputDecoration(labelText: 'Stacks'),
                   keyboardType: TextInputType.number,
                   onFieldSubmitted: (value) {
                     final parsed = int.tryParse(value);
                     if (parsed != null) {
-                      onMetadataChanged(stacks: parsed);
+                      widget.onMetadataChanged(stacks: parsed);
                     }
                   },
                 ),
@@ -172,7 +573,7 @@ class TablePanel extends StatelessWidget {
             children: [
               Expanded(
                 child: DropdownButtonFormField<SoilType>(
-                  initialValue: site.soil,
+                  value: widget.site.soil,
                   decoration: const InputDecoration(labelText: 'Soil'),
                   items: SoilType.values
                       .map(
@@ -182,13 +583,13 @@ class TablePanel extends StatelessWidget {
                         ),
                       )
                       .toList(),
-                  onChanged: (soil) => onMetadataChanged(soil: soil),
+                  onChanged: (soil) => widget.onMetadataChanged(soil: soil),
                 ),
               ),
               const SizedBox(width: 12),
               Expanded(
                 child: DropdownButtonFormField<MoistureLevel>(
-                  initialValue: site.moisture,
+                  value: widget.site.moisture,
                   decoration: const InputDecoration(labelText: 'Moisture'),
                   items: MoistureLevel.values
                       .map(
@@ -198,7 +599,7 @@ class TablePanel extends StatelessWidget {
                         ),
                       )
                       .toList(),
-                  onChanged: (level) => onMetadataChanged(moisture: level),
+                  onChanged: (level) => widget.onMetadataChanged(moisture: level),
                 ),
               ),
             ],
@@ -207,283 +608,87 @@ class TablePanel extends StatelessWidget {
       ),
     );
   }
-}
+  void _syncControllers(List<_FieldKey> keys, Map<_FieldKey, String> values) {
+    final staleKeys = _controllers.keys.where((key) => !keys.contains(key)).toList();
+    for (final key in staleKeys) {
+      _controllers.remove(key)?.dispose();
+      _focusNodes.remove(key)?.dispose();
+    }
 
-class _SpacingRow extends StatelessWidget {
-  const _SpacingRow({
-    required this.record,
-    required this.flags,
-    required this.onResistanceChanged,
-    required this.onSdChanged,
-    required this.onNoteChanged,
-    required this.onToggleBad,
-    required this.onShowHistory,
-    required this.onFocusChanged,
-  });
-
-  final SpacingRecord record;
-  final QcFlags flags;
-  final void Function(OrientationKind orientation, double? resistance)
-      onResistanceChanged;
-  final void Function(OrientationKind orientation, double? sd) onSdChanged;
-  final void Function(OrientationKind orientation, String note) onNoteChanged;
-  final void Function(OrientationKind orientation, bool isBad) onToggleBad;
-  final Future<void> Function(OrientationKind orientation) onShowHistory;
-  final void Function(OrientationKind orientation) onFocusChanged;
-
-  @override
-  Widget build(BuildContext context) {
-    final insideFt = record.tapeInsideFeet;
-    final outsideFt = record.tapeOutsideFeet;
-    return Card(
-      margin: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-      child: Padding(
-        padding: const EdgeInsets.all(12.0),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Row(
-              children: [
-                Text(
-                  'a = ${record.spacingFeet.toStringAsFixed(1)} ft',
-                  style: Theme.of(context).textTheme.titleMedium,
-                ),
-                const SizedBox(width: 12),
-                Tooltip(
-                  message:
-                      'Inside: ${insideFt.toStringAsFixed(1)} ft (${feetToMeters(insideFt).toStringAsFixed(2)} m)\n'
-                      'Outside: ${outsideFt.toStringAsFixed(1)} ft (${feetToMeters(outsideFt).toStringAsFixed(2)} m)',
-                  child: Chip(
-                    avatar: const Icon(Icons.straighten),
-                    label: Text(
-                        'Inside ${insideFt.toStringAsFixed(1)} ft • Outside ${outsideFt.toStringAsFixed(1)} ft'),
-                  ),
-                ),
-                const Spacer(),
-                if (flags.outlier)
-                  Padding(
-                    padding: const EdgeInsets.symmetric(horizontal: 4.0),
-                    child: Chip(
-                      label: const Text('Outlier'),
-                      backgroundColor: Theme.of(context).colorScheme.errorContainer,
-                    ),
-                  ),
-                if (flags.highVariance)
-                  Padding(
-                    padding: const EdgeInsets.symmetric(horizontal: 4.0),
-                    child: Chip(
-                      label: const Text('High %SD'),
-                      backgroundColor: Theme.of(context).colorScheme.tertiaryContainer,
-                    ),
-                  ),
-                if (flags.anisotropy)
-                  Padding(
-                    padding: const EdgeInsets.symmetric(horizontal: 4.0),
-                    child: Chip(
-                      label: const Text('Anisotropy'),
-                      backgroundColor: Theme.of(context).colorScheme.secondaryContainer,
-                    ),
-                  ),
-                if (flags.jump)
-                  Padding(
-                    padding: const EdgeInsets.symmetric(horizontal: 4.0),
-                    child: Chip(
-                      label: const Text('Jump'),
-                      backgroundColor: Theme.of(context).colorScheme.primaryContainer,
-                    ),
-                  ),
-              ],
-            ),
-            const SizedBox(height: 12),
-            Row(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Expanded(
-                  child: _OrientationCell(
-                    history: record.orientationA,
-                    onFocus: () => onFocusChanged(OrientationKind.a),
-                    onResistanceChanged: (value) =>
-                        onResistanceChanged(OrientationKind.a, value),
-                    onSdChanged: (value) => onSdChanged(OrientationKind.a, value),
-                    onNoteChanged: (value) => onNoteChanged(OrientationKind.a, value),
-                    onToggleBad: (value) => onToggleBad(OrientationKind.a, value),
-                    onShowHistory: () => onShowHistory(OrientationKind.a),
-                  ),
-                ),
-                const SizedBox(width: 12),
-                Expanded(
-                  child: _OrientationCell(
-                    history: record.orientationB,
-                    onFocus: () => onFocusChanged(OrientationKind.b),
-                    onResistanceChanged: (value) =>
-                        onResistanceChanged(OrientationKind.b, value),
-                    onSdChanged: (value) => onSdChanged(OrientationKind.b, value),
-                    onNoteChanged: (value) => onNoteChanged(OrientationKind.b, value),
-                    onToggleBad: (value) => onToggleBad(OrientationKind.b, value),
-                    onShowHistory: () => onShowHistory(OrientationKind.b),
-                  ),
-                ),
-              ],
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-}
-
-class _OrientationCell extends StatefulWidget {
-  const _OrientationCell({
-    required this.history,
-    required this.onFocus,
-    required this.onResistanceChanged,
-    required this.onSdChanged,
-    required this.onNoteChanged,
-    required this.onToggleBad,
-    required this.onShowHistory,
-  });
-
-  final DirectionReadingHistory history;
-  final VoidCallback onFocus;
-  final ValueChanged<double?> onResistanceChanged;
-  final ValueChanged<double?> onSdChanged;
-  final ValueChanged<String> onNoteChanged;
-  final ValueChanged<bool> onToggleBad;
-  final Future<void> Function() onShowHistory;
-
-  @override
-  State<_OrientationCell> createState() => _OrientationCellState();
-}
-
-class _OrientationCellState extends State<_OrientationCell> {
-  late TextEditingController _resistanceController;
-  late TextEditingController _sdController;
-  late FocusNode _resistanceFocus;
-  late FocusNode _sdFocus;
-
-  @override
-  void initState() {
-    super.initState();
-    _resistanceController = TextEditingController(
-      text: widget.history.latest?.resistanceOhm?.toStringAsFixed(2) ?? '',
-    );
-    _sdController = TextEditingController(
-      text: widget.history.latest?.standardDeviationPercent?.toStringAsFixed(1) ?? '',
-    );
-    _resistanceFocus = FocusNode();
-    _sdFocus = FocusNode();
-    _resistanceFocus.addListener(_handleFocus);
-    _sdFocus.addListener(_handleFocus);
-  }
-
-  @override
-  void didUpdateWidget(covariant _OrientationCell oldWidget) {
-    super.didUpdateWidget(oldWidget);
-    if (widget.history.latest?.timestamp != oldWidget.history.latest?.timestamp) {
-      _resistanceController.text =
-          widget.history.latest?.resistanceOhm?.toStringAsFixed(2) ?? '';
-      _sdController.text =
-          widget.history.latest?.standardDeviationPercent?.toStringAsFixed(1) ?? '';
+    for (final key in keys) {
+      final text = values[key] ?? '';
+      final controller =
+          _controllers.putIfAbsent(key, () => TextEditingController(text: text));
+      final focusNode = _focusNodes.putIfAbsent(key, () => _createFocusNode(key));
+      if (!focusNode.hasFocus && controller.text != text) {
+        controller.text = text;
+      }
     }
   }
 
-  @override
-  void dispose() {
-    _resistanceFocus.removeListener(_handleFocus);
-    _sdFocus.removeListener(_handleFocus);
-    _resistanceFocus.dispose();
-    _sdFocus.dispose();
-    _resistanceController.dispose();
-    _sdController.dispose();
-    super.dispose();
+  FocusNode _createFocusNode(_FieldKey key) {
+    final node = FocusNode();
+    if (key.orientation != null) {
+      node.addListener(() {
+        if (node.hasFocus) {
+          widget.onFocusChanged(key.spacingFeet, key.orientation!);
+        }
+      });
+    }
+    return node;
   }
 
-  void _handleFocus() {
-    if (_resistanceFocus.hasFocus || _sdFocus.hasFocus) {
-      widget.onFocus();
+  void _submitResistance(_FieldKey key, String value) {
+    final parsed = double.tryParse(value);
+    widget.onResistanceChanged(
+      key.spacingFeet,
+      key.orientation!,
+      parsed,
+      null,
+    );
+    _moveFocus(key);
+  }
+
+  void _submitSd(_FieldKey key, String value) {
+    final parsed = double.tryParse(value);
+    widget.onSdChanged(
+      key.spacingFeet,
+      key.orientation!,
+      parsed,
+    );
+    _moveFocus(key);
+  }
+
+  void _moveFocus(_FieldKey key) {
+    final next = _tabOrder[key];
+    if (next == null) {
+      _focusNodes[key]?.unfocus();
+      return;
+    }
+    final nextNode = _focusNodes[next];
+    if (nextNode != null) {
+      FocusScope.of(context).requestFocus(nextNode);
     }
   }
 
-  @override
-  Widget build(BuildContext context) {
-    final latest = widget.history.latest;
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Text(
-          widget.history.label,
-          style: Theme.of(context).textTheme.titleSmall,
-        ),
-        const SizedBox(height: 8),
-        TextFormField(
-          controller: _resistanceController,
-          focusNode: _resistanceFocus,
-          decoration: const InputDecoration(labelText: 'R (Ω)'),
-          keyboardType: const TextInputType.numberWithOptions(decimal: true),
-          onFieldSubmitted: (value) {
-            widget.onResistanceChanged(double.tryParse(value));
-          },
-        ),
-        const SizedBox(height: 8),
-        TextFormField(
-          controller: _sdController,
-          focusNode: _sdFocus,
-          decoration: const InputDecoration(labelText: '%SD'),
-          keyboardType: const TextInputType.numberWithOptions(decimal: true),
-          onFieldSubmitted: (value) {
-            widget.onSdChanged(double.tryParse(value));
-          },
-        ),
-        Row(
-          children: [
-            Checkbox(
-              value: latest?.isBad ?? false,
-              onChanged: (value) {
-                widget.onToggleBad(value ?? false);
-              },
-            ),
-            const Text('Bad'),
-            const Spacer(),
-            IconButton(
-              icon: const Icon(Icons.note_alt),
-              tooltip: 'Edit note',
-              onPressed: () async {
-                final controller = TextEditingController(text: latest?.note ?? '');
-                final note = await showDialog<String>(
-                  context: context,
-                  builder: (context) => AlertDialog(
-                    title: Text('Note — ${widget.history.label}'),
-                    content: TextField(
-                      controller: controller,
-                      decoration: const InputDecoration(labelText: 'Note'),
-                      maxLines: 3,
-                    ),
-                    actions: [
-                      TextButton(
-                        onPressed: () => Navigator.of(context).pop(latest?.note ?? ''),
-                        child: const Text('Cancel'),
-                      ),
-                      FilledButton(
-                        onPressed: () =>
-                            Navigator.of(context).pop(controller.text.trim()),
-                        child: const Text('Save'),
-                      ),
-                    ],
-                  ),
-                );
-                if (note != null) {
-                  widget.onNoteChanged(note);
-                }
-              },
-            ),
-            IconButton(
-              icon: const Icon(Icons.history),
-              tooltip: 'Re-read history',
-              onPressed: widget.onShowHistory,
-            ),
-          ],
-        ),
-      ],
-    );
+  DirectionReadingSample? _latestSample(DirectionReadingHistory history) {
+    if (history.samples.isEmpty) {
+      return null;
+    }
+    return history.samples.last;
+  }
+
+  String _formatResistance(double? value) {
+    if (value == null || value.isNaN || value.isInfinite) {
+      return '';
+    }
+    return value.toStringAsFixed(2);
+  }
+
+  String _formatSd(double? value) {
+    if (value == null || value.isNaN || value.isInfinite) {
+      return '';
+    }
+    return value.toStringAsFixed(1);
   }
 }

--- a/test/qc_rules_test.dart
+++ b/test/qc_rules_test.dart
@@ -27,21 +27,21 @@ SpacingPoint _makePoint(double rho, {double? sigma}) {
 }
 
 void main() {
-  test('Green classification stays below thresholds', () {
-    final point = _makePoint(100.0, sigma: 2.0);
+  test('Green classification includes threshold boundary', () {
+    final point = _makePoint(100.0, sigma: kQaGreenCvLimit * 100.0);
     final level = classifyPoint(
-      residual: kQaGreenResidualLimit / 2,
-      coefficientOfVariation: kQaGreenCvLimit / 2,
+      residual: kQaGreenResidualLimit,
+      coefficientOfVariation: kQaGreenCvLimit,
       point: point,
     );
     expect(level, QaLevel.green);
   });
 
-  test('Yellow classification when hitting green thresholds', () {
-    final point = _makePoint(120.0, sigma: kQaGreenCvLimit * 120.0);
+  test('Yellow classification slightly above green thresholds', () {
+    final point = _makePoint(120.0, sigma: (kQaGreenCvLimit + 0.001) * 120.0);
     final level = classifyPoint(
-      residual: kQaGreenResidualLimit,
-      coefficientOfVariation: kQaGreenCvLimit,
+      residual: kQaGreenResidualLimit + 0.001,
+      coefficientOfVariation: kQaGreenCvLimit + 0.001,
       point: point,
     );
     expect(level, QaLevel.yellow);

--- a/test/site_record_test.dart
+++ b/test/site_record_test.dart
@@ -1,0 +1,14 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:ves_qc/models/calc.dart';
+import 'package:ves_qc/models/site.dart';
+
+void main() {
+  test('tape helper values convert correctly for 2.5 ft spacing', () {
+    final record = SpacingRecord.seed(spacingFeet: 2.5);
+    expect(record.tapeInsideFeet, closeTo(1.25, 1e-9));
+    expect(record.tapeOutsideFeet, closeTo(3.75, 1e-9));
+    expect(record.tapeInsideMeters, closeTo(feetToMeters(1.25), 1e-9));
+    expect(record.tapeOutsideMeters, closeTo(feetToMeters(3.75), 1e-9));
+  });
+}

--- a/test/ui_update_test.dart
+++ b/test/ui_update_test.dart
@@ -43,4 +43,42 @@ void main() {
     final shown = buildSeriesForSite(site, showOutliers: true);
     expect(shown.aSeries.length, 1);
   });
+
+  test('hide outliers keeps unflagged high resistance readings visible', () {
+    final site = SiteRecord(
+      siteId: 'SiteB',
+      displayName: 'Site B',
+      spacings: [
+        SpacingRecord(
+          spacingFeet: 10,
+          orientationA: DirectionReadingHistory(
+            orientation: OrientationKind.a,
+            label: 'N–S',
+            samples: [
+              DirectionReadingSample(
+                timestamp: DateTime.now(),
+                resistanceOhm: 250000,
+                isBad: false,
+              ),
+            ],
+          ),
+          orientationB: DirectionReadingHistory(
+            orientation: OrientationKind.b,
+            label: 'W–E',
+            samples: [
+              DirectionReadingSample(
+                timestamp: DateTime.now(),
+                resistanceOhm: 240000,
+                isBad: false,
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+
+    final hidden = buildSeriesForSite(site, showOutliers: false);
+    expect(hidden.aSeries, isNotEmpty);
+    expect(hidden.bSeries, isNotEmpty);
+  });
 }


### PR DESCRIPTION
## Summary
- replace the field entry cards with a scrollable DataTable that keeps focus order predictable, surfaces tape helper tooltips, and exposes an editable interpretation column
- persist interpretation presets on spacing records, auto-fill them from %SD, and ensure the hide-outliers toggle only filters samples flagged bad while plots honour the same rule
- tighten QA threshold comparisons and expand unit coverage for hide-outlier regression and tape helper precision

## Testing
- flutter test *(fails: Flutter is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e677e73784832e8741a68929c63037